### PR TITLE
Use Jakarta JAXB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # Codex
 
-This repository contains a sample Spring Batch project for processing PEPPOL UBL invoices. The batch job reads XML invoice files from the `input` directory and writes them unchanged to the `output` directory. The XML structure follows the PEPPOL UBL 2.1 specification.
+This repository contains a sample Spring Batch project for processing PEPPOL UBL invoices. The XML files adhere to the UBL 2.1 specification. The batch job is organised into two tasklet based steps: the first reads invoices from the `input` directory and stores them in the job context, while the second writes the invoices to the `output` directory.
+
+Sample invoice XML files are located under `peppol-batch/src/test/resources`. In addition to `sample-invoice.xml`, a more detailed example is provided in `complex-invoice.xml`.
+
+## Maven configuration
+
+The `peppol-batch/pom.xml` file declares the dependencies needed for the batch job:
+- `spring-boot-starter-batch` and `spring-boot-starter` provide Spring Batch support.
+- `pdfbox` enables extracting embedded XML from PDFs.
+- `spring-boot-starter-test` supplies JUnit for tests.
+- `peppol-ubl21` provides JAXB classes for working with UBL 2.1 invoices.
+- `jakarta.xml.bind-api` and `jaxb-runtime` bring in Jakarta JAXB 4 so the code
+  compiles on Java 17.
+
+The build uses the `spring-boot-maven-plugin` to create an executable JAR.
 
 ## Building
 
@@ -28,3 +42,63 @@ java -jar target/peppol-batch-0.0.1-SNAPSHOT.jar
 ```
 
 The XML files will be created in the `output` directory with the same file names.
+
+## Parsing invoices to Java objects
+
+The project includes a simple `UblInvoiceParser` that uses `jakarta.xml.bind`
+via the `peppol-ubl21` library to convert invoice XML into JAXB classes. The following snippet parses
+an invoice and prints its ID:
+
+```java
+String xml = Files.readString(Path.of("complex-invoice.xml"));
+UblInvoiceParser parser = new UblInvoiceParser();
+InvoiceType invoice = parser.parse(xml);
+System.out.println(invoice.getID().getValue());
+```
+
+## Using samples from the Oxalis peppol-specifications repository
+
+To try additional invoice examples, clone the specifications repository next to this project:
+
+```bash
+git clone https://github.com/OxalisCommunity/peppol-specifications.git
+```
+
+After cloning, run the batch job pointing the `input` directory at one of the XML files from the cloned repository. You can also run the test `SpecificationsInvoiceTest` by providing the repository location using the `peppolSpecDir` system property:
+
+```bash
+mvn test -DpeppolSpecDir=../peppol-specifications
+```
+
+The `SpecificationsInvoiceTest` reads the first XML file it can find in the
+cloned repository and writes the invoice to a temporary directory. The output
+path is reported by the test and the file contents should match the original
+invoice.
+
+The `InvoiceXmlFileReaderTest` demonstrates the same process using the bundled
+`complex-invoice.xml` sample. It prints the location of the generated file so
+you can inspect it after the test run.
+
+## Example end-to-end scenario
+
+The project can be extended into a full batch pipeline using the following
+approach:
+
+1. **Fetch archives** from an S3 compatible store and place them under
+   `/tmp/raw`.
+2. **Decrypt and unzip** each `zip.pgp` archive with a custom `Tasklet`. The
+   extracted XML files should end up in `/tmp/unzipped`.
+3. **Parse invoices** using a `MultiResourceItemReader<InvoiceType>` backed by
+   JAXB classes generated from the PEPPOL UBL 2.1 schemas.
+4. **Process invoices** as needed. The reference code simply re‑marshals them
+   without writing to a database.
+5. **Write results** to `/tmp/processed/xml` and generate placeholder PDFs in
+   `/tmp/processed/pdf`. A `NamespacePrefixMapper` ensures that the output uses
+   the standard `cac` and `cbc` prefixes with no `nsXX` namespaces.
+6. **Upload or deliver** the processed files if required.
+7. **Clean up** temporary directories so every job run starts with a clean
+   workspace.
+
+Running the batch job repeatedly can be achieved with a Spring `TaskScheduler`
+that launches it every minute.
+

--- a/peppol-batch/pom.xml
+++ b/peppol-batch/pom.xml
@@ -35,6 +35,21 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>network.oxalis.peppol</groupId>
+            <artifactId>peppol-ubl21</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.4</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceParser.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceParser.java
@@ -1,0 +1,31 @@
+package com.example.peppol.batch;
+
+import java.io.StringReader;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+
+/**
+ * Utility to parse UBL 2.1 invoice XML into JAXB objects.
+ */
+public class UblInvoiceParser {
+
+    /**
+     * Parse the given XML string into an {@link InvoiceType} instance.
+     *
+     * @param xml invoice XML
+     * @return parsed {@link InvoiceType}
+     */
+    public InvoiceType parse(String xml) {
+        try {
+            JAXBContext ctx = JAXBContext.newInstance(InvoiceType.class);
+            Unmarshaller unmarshaller = ctx.createUnmarshaller();
+            return (InvoiceType) unmarshaller.unmarshal(new StringReader(xml));
+        } catch (JAXBException e) {
+            throw new RuntimeException("Failed to parse invoice", e);
+        }
+    }
+}

--- a/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/InvoiceReadTasklet.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/InvoiceReadTasklet.java
@@ -1,0 +1,36 @@
+package com.example.peppol.batch.tasklet;
+
+import com.example.peppol.batch.InvoiceDocument;
+import com.example.peppol.batch.InvoiceXmlFileReader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * Tasklet that reads invoice XML files and stores them in the job context.
+ */
+public class InvoiceReadTasklet implements Tasklet {
+
+    private final Path inputDir;
+
+    public InvoiceReadTasklet(Path inputDir) {
+        this.inputDir = inputDir;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        InvoiceXmlFileReader reader = new InvoiceXmlFileReader(inputDir);
+        List<InvoiceDocument> docs = new ArrayList<>();
+        InvoiceDocument doc;
+        while ((doc = reader.read()) != null) {
+            docs.add(doc);
+        }
+        chunkContext.getStepContext().getStepExecution()
+                .getJobExecution().getExecutionContext().put("invoices", docs);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/InvoiceWriteTasklet.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/InvoiceWriteTasklet.java
@@ -1,0 +1,37 @@
+package com.example.peppol.batch.tasklet;
+
+import com.example.peppol.batch.InvoiceDocument;
+import com.example.peppol.batch.InvoiceXmlWriter;
+import java.nio.file.Path;
+import java.util.List;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.item.Chunk;
+
+/**
+ * Tasklet that writes invoices stored in the job context to files.
+ */
+public class InvoiceWriteTasklet implements Tasklet {
+
+    private final Path outputDir;
+
+    public InvoiceWriteTasklet(Path outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        List<InvoiceDocument> docs = (List<InvoiceDocument>) chunkContext.getStepContext()
+                .getStepExecution().getJobExecution().getExecutionContext().get("invoices");
+        if (docs != null && !docs.isEmpty()) {
+            InvoiceXmlWriter writer = new InvoiceXmlWriter(outputDir);
+            Chunk<InvoiceDocument> chunk = new Chunk<>();
+            chunk.addAll(docs);
+            writer.write(chunk);
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/InvoiceTaskletTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/InvoiceTaskletTest.java
@@ -1,0 +1,45 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.example.peppol.batch.tasklet.InvoiceReadTasklet;
+import com.example.peppol.batch.tasklet.InvoiceWriteTasklet;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+class InvoiceTaskletTest {
+
+    @Test
+    void readsAndWritesInvoiceUsingTasklets() throws Exception {
+        Path inputDir = Files.createTempDirectory("tasklet-in");
+        Path sample = Path.of("src/test/resources/sample-invoice.xml");
+        Files.copy(sample, inputDir.resolve("invoice1.xml"));
+
+        Path outputDir = Files.createTempDirectory("tasklet-out");
+
+        JobExecution jobExecution = new JobExecution(1L, new JobParameters());
+        StepExecution readExecution = new StepExecution("readStep", jobExecution);
+        ChunkContext readContext = new ChunkContext(new StepContext(readExecution));
+        StepContribution readContribution = new StepContribution(readExecution);
+
+        InvoiceReadTasklet readTasklet = new InvoiceReadTasklet(inputDir);
+        readTasklet.execute(readContribution, readContext);
+
+        StepExecution writeExecution = new StepExecution("writeStep", jobExecution);
+        ChunkContext writeContext = new ChunkContext(new StepContext(writeExecution));
+        StepContribution writeContribution = new StepContribution(writeExecution);
+
+        InvoiceWriteTasklet writeTasklet = new InvoiceWriteTasklet(outputDir);
+        writeTasklet.execute(writeContribution, writeContext);
+
+        assertTrue(Files.exists(outputDir.resolve("invoice1.xml")));
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/InvoiceXmlFileReaderTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/InvoiceXmlFileReaderTest.java
@@ -2,6 +2,7 @@ package com.example.peppol.batch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -9,6 +10,9 @@ import java.nio.file.StandardCopyOption;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.Chunk;
+
+import com.example.peppol.batch.InvoiceXmlWriter;
 
 class InvoiceXmlFileReaderTest {
 
@@ -28,5 +32,42 @@ class InvoiceXmlFileReaderTest {
         assertNotNull(doc);
         String expected = Files.readString(tempDir.resolve("invoice1.xml"));
         assertEquals(expected, doc.getXml());
+    }
+
+    @Test
+    void readsComplexInvoice() throws Exception {
+        Path dir = Files.createTempDirectory("complex-invoices");
+        Path sample = Path.of("src/test/resources/complex-invoice.xml");
+        Files.copy(sample, dir.resolve("invoice1.xml"), StandardCopyOption.REPLACE_EXISTING);
+
+        InvoiceXmlFileReader reader = new InvoiceXmlFileReader(dir);
+        InvoiceDocument doc = reader.read();
+
+        assertNotNull(doc);
+        String expected = Files.readString(dir.resolve("invoice1.xml"));
+        assertEquals(expected, doc.getXml());
+    }
+
+    @Test
+    void readsComplexInvoiceAndGeneratesFileElsewhere() throws Exception {
+        Path inputDir = Files.createTempDirectory("complex-invoices-in");
+        Path sample = Path.of("src/test/resources/complex-invoice.xml");
+        Path inputFile = inputDir.resolve("invoice1.xml");
+        Files.copy(sample, inputFile, StandardCopyOption.REPLACE_EXISTING);
+
+        InvoiceXmlFileReader reader = new InvoiceXmlFileReader(inputDir);
+        InvoiceDocument doc = reader.read();
+        assertNotNull(doc);
+
+        Path outputDir = Files.createTempDirectory("complex-invoices-out");
+        InvoiceXmlWriter writer = new InvoiceXmlWriter(outputDir);
+        Chunk<InvoiceDocument> chunk = new Chunk<>();
+        chunk.add(doc);
+        writer.write(chunk);
+
+        Path written = outputDir.resolve("invoice1.xml");
+        System.out.println("Written file: " + written);
+        assertTrue(Files.exists(written));
+        assertEquals(Files.readString(sample), Files.readString(written));
     }
 }

--- a/peppol-batch/src/test/java/com/example/peppol/batch/InvoiceXmlWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/InvoiceXmlWriterTest.java
@@ -34,4 +34,23 @@ class InvoiceXmlWriterTest {
         assertTrue(Files.exists(written));
         assertEquals(xml, Files.readString(written));
     }
+
+    @Test
+    void writesComplexInvoiceXmlToFile() throws Exception {
+        Path outputDir = Files.createTempDirectory("complex-invoices-test");
+
+        String xml = Files.readString(Path.of("src/test/resources/complex-invoice.xml"));
+
+        InvoiceDocument doc = new InvoiceDocument(xml, Path.of("invoice1.xml"));
+
+        Chunk<InvoiceDocument> chunk = new Chunk<>();
+        chunk.add(doc);
+
+        InvoiceXmlWriter writer = new InvoiceXmlWriter(outputDir);
+        writer.write(chunk);
+
+        Path written = outputDir.resolve("invoice1.xml");
+        assertTrue(Files.exists(written));
+        assertEquals(xml, Files.readString(written));
+    }
 }

--- a/peppol-batch/src/test/java/com/example/peppol/batch/SpecificationsInvoiceTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/SpecificationsInvoiceTest.java
@@ -1,0 +1,62 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.springframework.batch.item.Chunk;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reads an invoice sample from the Oxalis peppol-specifications repository if present.
+ * The repository location can be provided using the system property 'peppolSpecDir'.
+ */
+class SpecificationsInvoiceTest {
+
+    @Test
+    void readsInvoiceFromSpecificationsRepo() throws Exception {
+        Path repo = Path.of(System.getProperty("peppolSpecDir", "../peppol-specifications"));
+        assumeTrue(Files.isDirectory(repo), "peppol-specifications repo not found");
+
+        Optional<Path> example = findFirstXml(repo);
+        assumeTrue(example.isPresent(), "No XML invoice found in repo");
+
+        InvoiceXmlFileReader reader = new InvoiceXmlFileReader(example.get().getParent());
+        InvoiceDocument doc = reader.read();
+        assertNotNull(doc);
+    }
+
+    @Test
+    void readsAndWritesInvoiceFromSpecificationsRepo() throws Exception {
+        Path repo = Path.of(System.getProperty("peppolSpecDir", "../peppol-specifications"));
+        assumeTrue(Files.isDirectory(repo), "peppol-specifications repo not found");
+
+        Optional<Path> example = findFirstXml(repo);
+        assumeTrue(example.isPresent(), "No XML invoice found in repo");
+
+        InvoiceXmlFileReader reader = new InvoiceXmlFileReader(example.get().getParent());
+        InvoiceDocument doc = reader.read();
+        assertNotNull(doc);
+
+        Path outDir = Files.createTempDirectory("spec-invoice-out");
+        InvoiceXmlWriter writer = new InvoiceXmlWriter(outDir);
+        Chunk<InvoiceDocument> chunk = new Chunk<>();
+        chunk.add(doc);
+        writer.write(chunk);
+
+        Path written = outDir.resolve(example.get().getFileName());
+        assumeTrue(Files.exists(written), "invoice not written" );
+    }
+
+    private Optional<Path> findFirstXml(Path dir) throws Exception {
+        try (Stream<Path> s = Files.walk(dir)) {
+            return s.filter(p -> p.toString().toLowerCase().endsWith(".xml"))
+                    .findFirst();
+        }
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceParserTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceParserTest.java
@@ -1,0 +1,23 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+
+class UblInvoiceParserTest {
+
+    @Test
+    void parsesComplexInvoice() throws Exception {
+        String xml = Files.readString(Path.of("src/test/resources/complex-invoice.xml"));
+        UblInvoiceParser parser = new UblInvoiceParser();
+        InvoiceType invoice = parser.parse(xml);
+        assertNotNull(invoice);
+        assertEquals("TickstarAP-BIS3-test-01", invoice.getID().getValue());
+    }
+}

--- a/peppol-batch/src/test/resources/complex-invoice.xml
+++ b/peppol-batch/src/test/resources/complex-invoice.xml
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+<cbc:ID>TickstarAP-BIS3-test-01</cbc:ID>
+<cbc:IssueDate>2023-12-19</cbc:IssueDate>
+<cbc:DueDate>2024-01-18</cbc:DueDate>
+<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+<cbc:Note>GalaxyGateway hosted AP BIS3 Billing Test file</cbc:Note>
+<cbc:TaxPointDate>2023-12-19</cbc:TaxPointDate>
+<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+<cbc:TaxCurrencyCode>SEK</cbc:TaxCurrencyCode>
+<cbc:AccountingCost>4025:123:4343</cbc:AccountingCost>
+<cbc:BuyerReference>0150abc</cbc:BuyerReference>
+<cac:InvoicePeriod>
+<cbc:StartDate>2023-11-01</cbc:StartDate>
+<cbc:EndDate>2032-12-31</cbc:EndDate>
+</cac:InvoicePeriod>
+<cac:ContractDocumentReference>
+<cbc:ID>framework no 1</cbc:ID>
+</cac:ContractDocumentReference>
+<cac:AdditionalDocumentReference>
+<cbc:ID schemeID="ABT">DR35141</cbc:ID>
+<cbc:DocumentTypeCode>130</cbc:DocumentTypeCode>
+</cac:AdditionalDocumentReference>
+<cac:AdditionalDocumentReference>
+<cbc:ID>ts12345</cbc:ID>
+<cbc:DocumentDescription>Technical specification</cbc:DocumentDescription>
+<cac:Attachment>
+<cac:ExternalReference>
+<cbc:URI>www.techspec.no</cbc:URI>
+</cac:ExternalReference>
+</cac:Attachment>
+</cac:AdditionalDocumentReference>
+<cac:AccountingSupplierParty>
+<cac:Party>
+<cbc:EndpointID schemeID="0088">9999993010</cbc:EndpointID>
+<cac:PartyIdentification>
+<cbc:ID>99887766</cbc:ID>
+</cac:PartyIdentification>
+<cac:PartyName>
+<cbc:Name>SupplierTradingName Ltd.</cbc:Name>
+</cac:PartyName>
+<cac:PostalAddress>
+<cbc:StreetName>Main street 1</cbc:StreetName>
+<cbc:AdditionalStreetName>Postbox 123</cbc:AdditionalStreetName>
+<cbc:CityName>London</cbc:CityName>
+<cbc:PostalZone>GB 123 EW</cbc:PostalZone>
+<cac:Country>
+<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+</cac:Country>
+</cac:PostalAddress>
+<cac:PartyTaxScheme>
+<cbc:CompanyID>GB1232434</cbc:CompanyID>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:PartyTaxScheme>
+<cac:PartyLegalEntity>
+<cbc:RegistrationName>SupplierOfficialName Ltd</cbc:RegistrationName>
+<cbc:CompanyID>GB983294</cbc:CompanyID>
+<cbc:CompanyLegalForm>AdditionalLegalInformation</cbc:CompanyLegalForm>
+</cac:PartyLegalEntity>
+</cac:Party>
+</cac:AccountingSupplierParty>
+<cac:AccountingCustomerParty>
+<cac:Party>
+<cbc:EndpointID schemeID="0007">9999993010</cbc:EndpointID>
+<cac:PartyIdentification>
+<cbc:ID schemeID="0007">9999993010</cbc:ID>
+</cac:PartyIdentification>
+<cac:PartyName>
+<cbc:Name>BuyerTradingName AS</cbc:Name>
+</cac:PartyName>
+<cac:PostalAddress>
+<cbc:StreetName>Hovedgatan 32</cbc:StreetName>
+<cbc:AdditionalStreetName>Po box 878</cbc:AdditionalStreetName>
+<cbc:CityName>Stockholm</cbc:CityName>
+<cbc:PostalZone>456 34</cbc:PostalZone>
+<cbc:CountrySubentity>Södermalm</cbc:CountrySubentity>
+<cac:Country>
+<cbc:IdentificationCode>SE</cbc:IdentificationCode>
+</cac:Country>
+</cac:PostalAddress>
+<cac:PartyTaxScheme>
+<cbc:CompanyID>SE4598375937</cbc:CompanyID>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:PartyTaxScheme>
+<cac:PartyLegalEntity>
+<cbc:RegistrationName>Buyer Official Name</cbc:RegistrationName>
+<cbc:CompanyID schemeID="0183">39937423947</cbc:CompanyID>
+</cac:PartyLegalEntity>
+<cac:Contact>
+<cbc:Name>Lisa Johnson</cbc:Name>
+<cbc:Telephone>23434234</cbc:Telephone>
+<cbc:ElectronicMail>lj@buyer.se</cbc:ElectronicMail>
+</cac:Contact>
+</cac:Party>
+</cac:AccountingCustomerParty>
+<cac:Delivery>
+<cbc:ActualDeliveryDate>2023-12-01</cbc:ActualDeliveryDate>
+<cac:DeliveryLocation>
+<cbc:ID schemeID="0088">7300010000001</cbc:ID>
+<cac:Address>
+<cbc:StreetName>Delivery street 2</cbc:StreetName>
+<cbc:AdditionalStreetName>Building 56</cbc:AdditionalStreetName>
+<cbc:CityName>Stockholm</cbc:CityName>
+<cbc:PostalZone>21234</cbc:PostalZone>
+<cbc:CountrySubentity>Södermalm</cbc:CountrySubentity>
+<cac:AddressLine>
+<cbc:Line>Gate 15</cbc:Line>
+</cac:AddressLine>
+<cac:Country>
+<cbc:IdentificationCode>SE</cbc:IdentificationCode>
+</cac:Country>
+</cac:Address>
+</cac:DeliveryLocation>
+<cac:DeliveryParty>
+<cac:PartyName>
+<cbc:Name>Delivery party Name</cbc:Name>
+</cac:PartyName>
+</cac:DeliveryParty>
+</cac:Delivery>
+<cac:PaymentMeans>
+<cbc:PaymentMeansCode name="Credit transfer">30</cbc:PaymentMeansCode>
+<cbc:PaymentID>Snippet1</cbc:PaymentID>
+<cac:PayeeFinancialAccount>
+<cbc:ID>IBAN32423940</cbc:ID>
+<cbc:Name>AccountName</cbc:Name>
+<cac:FinancialInstitutionBranch>
+<cbc:ID>BIC324098</cbc:ID>
+</cac:FinancialInstitutionBranch>
+</cac:PayeeFinancialAccount>
+</cac:PaymentMeans>
+<cac:PaymentTerms>
+<cbc:Note>Payment within 10 days, 2% discount</cbc:Note>
+</cac:PaymentTerms>
+<cac:AllowanceCharge>
+<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+<cbc:AllowanceChargeReasonCode>CG</cbc:AllowanceChargeReasonCode>
+<cbc:AllowanceChargeReason>Cleaning</cbc:AllowanceChargeReason>
+<cbc:MultiplierFactorNumeric>20</cbc:MultiplierFactorNumeric>
+<cbc:Amount currencyID="EUR">200</cbc:Amount>
+<cbc:BaseAmount currencyID="EUR">1000</cbc:BaseAmount>
+<cac:TaxCategory>
+<cbc:ID>S</cbc:ID>
+<cbc:Percent>25</cbc:Percent>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:AllowanceCharge>
+<cac:AllowanceCharge>
+<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+<cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+<cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+<cbc:Amount currencyID="EUR">200</cbc:Amount>
+<cac:TaxCategory>
+<cbc:ID>S</cbc:ID>
+<cbc:Percent>25</cbc:Percent>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:AllowanceCharge>
+<cac:TaxTotal>
+<cbc:TaxAmount currencyID="EUR">1225.00</cbc:TaxAmount>
+<cac:TaxSubtotal>
+<cbc:TaxableAmount currencyID="EUR">4900.0</cbc:TaxableAmount>
+<cbc:TaxAmount currencyID="EUR">1225</cbc:TaxAmount>
+<cac:TaxCategory>
+<cbc:ID>S</cbc:ID>
+<cbc:Percent>25</cbc:Percent>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:TaxSubtotal>
+<cac:TaxSubtotal>
+<cbc:TaxableAmount currencyID="EUR">1000.0</cbc:TaxableAmount>
+<cbc:TaxAmount currencyID="EUR">0</cbc:TaxAmount>
+<cac:TaxCategory>
+<cbc:ID>E</cbc:ID>
+<cbc:Percent>0</cbc:Percent>
+<cbc:TaxExemptionReason>Reason for tax exempt</cbc:TaxExemptionReason>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:TaxSubtotal>
+</cac:TaxTotal>
+<cac:TaxTotal>
+<cbc:TaxAmount currencyID="SEK">9324.00</cbc:TaxAmount>
+</cac:TaxTotal>
+<cac:LegalMonetaryTotal>
+<cbc:LineExtensionAmount currencyID="EUR">5900</cbc:LineExtensionAmount>
+<cbc:TaxExclusiveAmount currencyID="EUR">5900</cbc:TaxExclusiveAmount>
+<cbc:TaxInclusiveAmount currencyID="EUR">7125</cbc:TaxInclusiveAmount>
+<cbc:AllowanceTotalAmount currencyID="EUR">200</cbc:AllowanceTotalAmount>
+<cbc:ChargeTotalAmount currencyID="EUR">200</cbc:ChargeTotalAmount>
+<cbc:PrepaidAmount currencyID="EUR">1000</cbc:PrepaidAmount>
+<cbc:PayableAmount currencyID="EUR">6125.00</cbc:PayableAmount>
+</cac:LegalMonetaryTotal>
+<cac:InvoiceLine>
+<cbc:ID>1</cbc:ID>
+<cbc:Note>Testing note on line level</cbc:Note>
+<cbc:InvoicedQuantity unitCode="C62">10</cbc:InvoicedQuantity>
+<cbc:LineExtensionAmount currencyID="EUR">4000.00</cbc:LineExtensionAmount>
+<cbc:AccountingCost>Konteringsstreng</cbc:AccountingCost>
+<cac:AllowanceCharge>
+<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+<cbc:AllowanceChargeReasonCode>CG</cbc:AllowanceChargeReasonCode>
+<cbc:AllowanceChargeReason>Cleaning</cbc:AllowanceChargeReason>
+<cbc:MultiplierFactorNumeric>1</cbc:MultiplierFactorNumeric>
+<cbc:Amount currencyID="EUR">1</cbc:Amount>
+<cbc:BaseAmount currencyID="EUR">100</cbc:BaseAmount>
+</cac:AllowanceCharge>
+<cac:AllowanceCharge>
+<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+<cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+<cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+<cbc:Amount currencyID="EUR">101</cbc:Amount>
+</cac:AllowanceCharge>
+<cac:Item>
+<cbc:Description>Description of item</cbc:Description>
+<cbc:Name>item name</cbc:Name>
+<cac:SellersItemIdentification>
+<cbc:ID>97iugug876</cbc:ID>
+</cac:SellersItemIdentification>
+<cac:OriginCountry>
+<cbc:IdentificationCode>NO</cbc:IdentificationCode>
+</cac:OriginCountry>
+<cac:CommodityClassification>
+<cbc:ItemClassificationCode listID="SRV">09348023</cbc:ItemClassificationCode>
+</cac:CommodityClassification>
+<cac:ClassifiedTaxCategory>
+<cbc:ID>S</cbc:ID>
+<cbc:Percent>25.0</cbc:Percent>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:ClassifiedTaxCategory>
+</cac:Item>
+<cac:Price>
+<cbc:PriceAmount currencyID="EUR">410</cbc:PriceAmount>
+<cbc:BaseQuantity unitCode="C62">1</cbc:BaseQuantity>
+<cac:AllowanceCharge>
+<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+<cbc:Amount currencyID="EUR">40</cbc:Amount>
+<cbc:BaseAmount currencyID="EUR">450</cbc:BaseAmount>
+</cac:AllowanceCharge>
+</cac:Price>
+</cac:InvoiceLine>
+<cac:InvoiceLine>
+<cbc:ID>2</cbc:ID>
+<cbc:Note>Testing note on line level</cbc:Note>
+<cbc:InvoicedQuantity unitCode="C62">10</cbc:InvoicedQuantity>
+<cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+<cbc:AccountingCost>AccountString</cbc:AccountingCost>
+<cac:InvoicePeriod>
+<cbc:StartDate>2023-12-01</cbc:StartDate>
+<cbc:EndDate>2032-12-05</cbc:EndDate>
+</cac:InvoicePeriod>
+<cac:OrderLineReference>
+<cbc:LineID>124</cbc:LineID>
+</cac:OrderLineReference>
+<cac:Item>
+<cbc:Description>Description of item</cbc:Description>
+<cbc:Name>item name</cbc:Name>
+<cac:SellersItemIdentification>
+<cbc:ID>97iugug876</cbc:ID>
+</cac:SellersItemIdentification>
+<cac:CommodityClassification>
+<cbc:ItemClassificationCode listID="SRV">86776</cbc:ItemClassificationCode>
+</cac:CommodityClassification>
+<cac:ClassifiedTaxCategory>
+<cbc:ID>E</cbc:ID>
+<cbc:Percent>0.0</cbc:Percent>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:ClassifiedTaxCategory>
+<cac:AdditionalItemProperty>
+<cbc:Name>AdditionalItemName</cbc:Name>
+<cbc:Value>AdditionalItemValue</cbc:Value>
+</cac:AdditionalItemProperty>
+</cac:Item>
+<cac:Price>
+<cbc:PriceAmount currencyID="EUR">200</cbc:PriceAmount>
+<cbc:BaseQuantity unitCode="C62">2</cbc:BaseQuantity>
+</cac:Price>
+</cac:InvoiceLine>
+<cac:InvoiceLine>
+<cbc:ID>3</cbc:ID>
+<cbc:Note>Testing note on line level</cbc:Note>
+<cbc:InvoicedQuantity unitCode="C62">10</cbc:InvoicedQuantity>
+<cbc:LineExtensionAmount currencyID="EUR">900.00</cbc:LineExtensionAmount>
+<cbc:AccountingCost>Konteringsstreng</cbc:AccountingCost>
+<cac:InvoicePeriod>
+<cbc:StartDate>2023-12-02</cbc:StartDate>
+<cbc:EndDate>2032-12-04</cbc:EndDate>
+</cac:InvoicePeriod>
+<cac:OrderLineReference>
+<cbc:LineID>124</cbc:LineID>
+</cac:OrderLineReference>
+<cac:AllowanceCharge>
+<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+<cbc:AllowanceChargeReasonCode>CG</cbc:AllowanceChargeReasonCode>
+<cbc:AllowanceChargeReason>Charge</cbc:AllowanceChargeReason>
+<cbc:MultiplierFactorNumeric>1</cbc:MultiplierFactorNumeric>
+<cbc:Amount currencyID="EUR">1</cbc:Amount>
+<cbc:BaseAmount currencyID="EUR">100</cbc:BaseAmount>
+</cac:AllowanceCharge>
+<cac:AllowanceCharge>
+<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+<cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+<cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+<cbc:Amount currencyID="EUR">101</cbc:Amount>
+</cac:AllowanceCharge>
+<cac:Item>
+<cbc:Description>Description of item</cbc:Description>
+<cbc:Name>item name</cbc:Name>
+<cac:SellersItemIdentification>
+<cbc:ID>97iugug876</cbc:ID>
+</cac:SellersItemIdentification>
+<cac:CommodityClassification>
+<cbc:ItemClassificationCode listID="SRV">86776</cbc:ItemClassificationCode>
+</cac:CommodityClassification>
+<cac:ClassifiedTaxCategory>
+<cbc:ID>S</cbc:ID>
+<cbc:Percent>25.0</cbc:Percent>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+</cac:TaxScheme>
+</cac:ClassifiedTaxCategory>
+<cac:AdditionalItemProperty>
+<cbc:Name>AdditionalItemName</cbc:Name>
+<cbc:Value>AdditionalItemValue</cbc:Value>
+</cac:AdditionalItemProperty>
+</cac:Item>
+<cac:Price>
+<cbc:PriceAmount currencyID="EUR">100</cbc:PriceAmount>
+</cac:Price>
+</cac:InvoiceLine>
+</Invoice>


### PR DESCRIPTION
## Summary
- add jakarta.xml.bind-api and jaxb-runtime dependencies
- update UblInvoiceParser to use the jakarta package
- mention Jakarta JAXB in README
- print the output path when the complex invoice test writes a file

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865020aaa3c832783f5e5127ba98c02