### PR TITLE
Add UBL invoice writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ InvoiceType invoice = parser.parse(xml);
 System.out.println(invoice.getID().getValue());
 ```
 
+Once an `InvoiceType` object is available it can be written back to XML using
+`UblInvoiceWriter`:
+
+```java
+UblInvoiceWriter writer = new UblInvoiceWriter();
+String out = writer.writeToString(invoice);
+Files.writeString(Path.of("invoice.xml"), out);
+```
+
 ## Using samples from the Oxalis peppol-specifications repository
 
 To try additional invoice examples, clone the specifications repository next to this project:

--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
@@ -1,0 +1,53 @@
+package com.example.peppol.batch;
+
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+
+import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+import network.oxalis.peppol.ubl2.jaxb.ObjectFactory;
+
+/**
+ * Utility to write {@link InvoiceType} instances to XML.
+ */
+public class UblInvoiceWriter {
+
+    /**
+     * Marshal the given invoice to a formatted XML string.
+     *
+     * @param invoice the invoice object
+     * @return XML representation
+     */
+    public String writeToString(InvoiceType invoice) {
+        try {
+            JAXBContext ctx = JAXBContext.newInstance("network.oxalis.peppol.ubl2.jaxb");
+            Marshaller marshaller = ctx.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            StringWriter sw = new StringWriter();
+            JAXBElement<InvoiceType> root = new ObjectFactory().createInvoice(invoice);
+            marshaller.marshal(root, sw);
+            return sw.toString();
+        } catch (JAXBException e) {
+            throw new RuntimeException("Failed to marshal invoice", e);
+        }
+    }
+
+    /**
+     * Marshal the invoice to the given file path.
+     *
+     * @param invoice the invoice to marshal
+     * @param output  the target file path
+     */
+    public void write(InvoiceType invoice, Path output) {
+        try {
+            Files.writeString(output, writeToString(invoice));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write invoice to " + output, e);
+        }
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceWriterTest.java
@@ -1,0 +1,31 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+
+class UblInvoiceWriterTest {
+
+    @Test
+    void writesInvoiceToXmlString() throws Exception {
+        String xml = Files.readString(Path.of("src/test/resources/complex-invoice.xml"));
+        UblInvoiceParser parser = new UblInvoiceParser();
+        InvoiceType invoice = parser.parse(xml);
+
+        UblInvoiceWriter writer = new UblInvoiceWriter();
+        String out = writer.writeToString(invoice);
+
+        assertNotNull(out);
+        assertFalse(out.isEmpty());
+
+        InvoiceType parsed = parser.parse(out);
+        assertEquals(invoice.getID().getValue(), parsed.getID().getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `UblInvoiceWriter` to marshal `InvoiceType` objects
- document how to use the writer in README
- test the writer with a new unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68653d8a7f2c8327835c7276ec827e2a