### PR TITLE
Fix JAXB compile error

### DIFF
--- a/peppol-batch/pom.xml
+++ b/peppol-batch/pom.xml
@@ -41,9 +41,8 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <scope>runtime</scope>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
 
         <dependency>

--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
@@ -10,7 +10,6 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import javax.xml.namespace.QName;
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
-import network.oxalis.peppol.ubl2.jaxb.ObjectFactory;
 
 /**
  * Utility to write {@link InvoiceType} instances to XML.

--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblNamespacePrefixMapper.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblNamespacePrefixMapper.java
@@ -1,6 +1,6 @@
 package com.example.peppol.batch;
 
-import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
+import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
 
 /**
  * Provides stable namespace prefixes for UBL invoice marshalling.


### PR DESCRIPTION
## Summary
- use `jaxb-runtime` for NamespacePrefixMapper
- remove unused import in `UblInvoiceWriter`
- import NamespacePrefixMapper from `org.glassfish.jaxb`

## Testing
- `mvn -version` *(fails: command not found)*
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865571e68648327840b70e2d4733d10