### PR TITLE
Fix JAXB marshalling error

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
@@ -27,7 +27,7 @@ public class UblInvoiceWriter {
             JAXBContext ctx = JAXBContext.newInstance(InvoiceType.class);
             Marshaller marshaller = ctx.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            marshaller.setProperty("com.sun.xml.bind.namespacePrefixMapper", new UblNamespacePrefixMapper());
+            marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new UblNamespacePrefixMapper());
             StringWriter sw = new StringWriter();
             JAXBElement<InvoiceType> root = new JAXBElement<>(
                     new QName("urn:oasis:names:specification:ubl:schema:xsd:Invoice-2", "Invoice"),


### PR DESCRIPTION
## Summary
- restore setting of the `NamespacePrefixMapper` property for JAXB marshalling

## Testing
- `mvn -q -f peppol-batch/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686563eae2b483279eb87b0a6f8850ae