### PR TITLE
Fix JAXB namespace mapping and output invoice file in tests

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
@@ -27,7 +27,7 @@ public class UblInvoiceWriter {
             JAXBContext ctx = JAXBContext.newInstance(InvoiceType.class);
             Marshaller marshaller = ctx.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            marshaller.setProperty("com.sun.xml.bind.namespacePrefixMapper", new UblNamespacePrefixMapper());
+            marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new UblNamespacePrefixMapper());
             StringWriter sw = new StringWriter();
             JAXBElement<InvoiceType> root = new JAXBElement<>(
                     new QName("urn:oasis:names:specification:ubl:schema:xsd:Invoice-2", "Invoice"),

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceWriterTest.java
@@ -25,6 +25,11 @@ class UblInvoiceWriterTest {
         UblInvoiceWriter writer = new UblInvoiceWriter();
         String out = writer.writeToString(invoice);
 
+        Path outFile = Path.of("target", "generated-invoice.xml");
+        Files.createDirectories(outFile.getParent());
+        writer.write(invoice, outFile);
+        log.info("Written invoice to {}", outFile.toAbsolutePath());
+
         assertNotNull(out);
         assertFalse(out.isEmpty());
 


### PR DESCRIPTION
## Summary
- ensure JAXB uses the `org.glassfish.jaxb.namespacePrefixMapper` property
- write generated invoice to `target/generated-invoice.xml` during tests

## Testing
- `mvn -q -f peppol-batch/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686563eae2b483279eb87b0a6f8850ae