### PR TITLE
Fix JAXB extension stripping compile error

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
@@ -27,7 +27,12 @@ public class UblInvoiceWriter {
             JAXBContext ctx = JAXBContext.newInstance(InvoiceType.class);
             Marshaller marshaller = ctx.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            marshaller.setProperty("com.sun.xml.bind.namespacePrefixMapper", new UblNamespacePrefixMapper());
+            marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new UblNamespacePrefixMapper());
+
+            var ext = invoice.getUBLExtensions();
+            if (ext != null && ext.getUBLExtension().isEmpty()) {
+                invoice.setUBLExtensions(null);
+            }
             StringWriter sw = new StringWriter();
             JAXBElement<InvoiceType> root = new JAXBElement<>(
                     new QName("urn:oasis:names:specification:ubl:schema:xsd:Invoice-2", "Invoice"),

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceWriterTest.java
@@ -25,6 +25,11 @@ class UblInvoiceWriterTest {
         UblInvoiceWriter writer = new UblInvoiceWriter();
         String out = writer.writeToString(invoice);
 
+        Path outFile = Path.of("target", "generated-invoice.xml");
+        Files.createDirectories(outFile.getParent());
+        writer.write(invoice, outFile);
+        log.info("Written invoice to {}", outFile.toAbsolutePath());
+
         assertNotNull(out);
         assertFalse(out.isEmpty());
 
@@ -33,6 +38,7 @@ class UblInvoiceWriterTest {
         log.info("parsed.getID().getValue(): {}", parsed.getID().getValue());
         assertEquals(invoice.getID().getValue(), parsed.getID().getValue());
         assertTrue(out.contains("<Invoice xmlns=\"urn:oasis:names:specification:ubl:schema:xsd:Invoice-2\""));
+        assertFalse(out.contains("CommonExtensionComponents-2"));
     }
 
 }


### PR DESCRIPTION
## Summary
- clean up empty UBL extensions without referencing `UBLExtensionsType`

## Testing
- `mvn -q -f peppol-batch/pom.xml test` *(fails to resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686563eae2b483279eb87b0a6f8850ae