### PR TITLE
Fix ext namespace removal

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblInvoiceWriter.java
@@ -40,7 +40,12 @@ public class UblInvoiceWriter {
                     InvoiceType.class, invoice);
 
             marshaller.marshal(root, sw);
-            return sw.toString();
+
+            String xml = sw.toString();
+            if (ext == null || ext.getUBLExtension().isEmpty()) {
+                xml = xml.replaceAll(" xmlns:[^=]*=\"urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2\"", "");
+            }
+            return xml;
         } catch (JAXBException e) {
             throw new RuntimeException("Failed to marshal invoice", e);
         }


### PR DESCRIPTION
## Summary
- remove CommonExtensionComponents namespace when no UBLExtensions are present

## Testing
- `mvn -q -Dtest=UblInvoiceWriterTest -DfailIfNoTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68657f0e37e48327835924bb847b7cc9