### PR TITLE
Support UBL Credit Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The XML files will be created in the `output` directory with the same file names
 
 The batch steps internally rely on `UblInvoiceParser` to read each invoice into
 `InvoiceType` objects and `UblInvoiceWriter` to write them back to XML.
+`UblCreditNoteParser` and `UblCreditNoteWriter` provide the same functionality
+for credit notes.
 
 
 
@@ -76,6 +78,15 @@ writer.write(invoice, outFile);
 The writer uses a `NamespacePrefixMapper` so the output starts with:
 `<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"` and
 declares the canonical `cac` and `cbc` prefixes.
+
+Similarly, credit notes can be handled with:
+
+```java
+UblCreditNoteParser cnParser = new UblCreditNoteParser();
+CreditNoteType creditNote = cnParser.parse(xml);
+UblCreditNoteWriter cnWriter = new UblCreditNoteWriter();
+cnWriter.write(creditNote, Path.of("credit-note.xml"));
+```
 
 
 ## Using samples from the Oxalis peppol-specifications repository

--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblCreditNoteParser.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblCreditNoteParser.java
@@ -1,0 +1,33 @@
+package com.example.peppol.batch;
+
+import java.io.StringReader;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
+
+/**
+ * Utility to parse UBL credit note XML into JAXB objects.
+ */
+public class UblCreditNoteParser {
+
+    /**
+     * Parse the given XML string into a {@link CreditNoteType} instance.
+     *
+     * @param xml credit note XML
+     * @return parsed {@link CreditNoteType}
+     */
+    public CreditNoteType parse(String xml) {
+        try {
+            JAXBContext ctx = JAXBContext.newInstance("network.oxalis.peppol.ubl2.jaxb");
+            Unmarshaller unmarshaller = ctx.createUnmarshaller();
+            JAXBElement<CreditNoteType> root = (JAXBElement<CreditNoteType>) unmarshaller.unmarshal(new StringReader(xml));
+            return root.getValue();
+        } catch (JAXBException e) {
+            throw new RuntimeException("Failed to parse credit note", e);
+        }
+    }
+}

--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblCreditNoteWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblCreditNoteWriter.java
@@ -9,35 +9,35 @@ import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import javax.xml.namespace.QName;
-import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
 
 /**
- * Utility to write {@link InvoiceType} instances to XML.
+ * Utility to write {@link CreditNoteType} instances to XML.
  */
-public class UblInvoiceWriter {
+public class UblCreditNoteWriter {
 
     /**
-     * Marshal the given invoice to a formatted XML string.
+     * Marshal the given credit note to a formatted XML string.
      *
-     * @param invoice the invoice object
+     * @param creditNote the credit note object
      * @return XML representation
      */
-    public String writeToString(InvoiceType invoice) {
+    public String writeToString(CreditNoteType creditNote) {
         try {
-            JAXBContext ctx = JAXBContext.newInstance(InvoiceType.class);
+            JAXBContext ctx = JAXBContext.newInstance(CreditNoteType.class);
             Marshaller marshaller = ctx.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new UblNamespacePrefixMapper());
 
-            var ext = invoice.getUBLExtensions();
+            var ext = creditNote.getUBLExtensions();
             if (ext != null && ext.getUBLExtension().isEmpty()) {
-                invoice.setUBLExtensions(null);
+                creditNote.setUBLExtensions(null);
             }
 
             StringWriter sw = new StringWriter();
-            JAXBElement<InvoiceType> root = new JAXBElement<>(
-                    new QName("urn:oasis:names:specification:ubl:schema:xsd:Invoice-2", "Invoice"),
-                    InvoiceType.class, invoice);
+            JAXBElement<CreditNoteType> root = new JAXBElement<>(
+                    new QName("urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2", "CreditNote"),
+                    CreditNoteType.class, creditNote);
 
             marshaller.marshal(root, sw);
 
@@ -47,21 +47,21 @@ public class UblInvoiceWriter {
             }
             return xml;
         } catch (JAXBException e) {
-            throw new RuntimeException("Failed to marshal invoice", e);
+            throw new RuntimeException("Failed to marshal credit note", e);
         }
     }
 
     /**
-     * Marshal the invoice to the given file path.
+     * Marshal the credit note to the given file path.
      *
-     * @param invoice the invoice to marshal
+     * @param creditNote the credit note to marshal
      * @param output  the target file path
      */
-    public void write(InvoiceType invoice, Path output) {
+    public void write(CreditNoteType creditNote, Path output) {
         try {
-            Files.writeString(output, writeToString(invoice));
+            Files.writeString(output, writeToString(creditNote));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to write invoice to " + output, e);
+            throw new RuntimeException("Failed to write credit note to " + output, e);
         }
     }
 }

--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblNamespacePrefixMapper.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblNamespacePrefixMapper.java
@@ -7,13 +7,14 @@ import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
  */
 public class UblNamespacePrefixMapper extends NamespacePrefixMapper {
     private static final String INVOICE_NS = "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2";
+    private static final String CREDIT_NOTE_NS = "urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2";
     private static final String CAC_NS = "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2";
     private static final String CBC_NS = "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2";
 
     @Override
     public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
         return switch (namespaceUri) {
-            case INVOICE_NS -> ""; // default namespace
+            case INVOICE_NS, CREDIT_NOTE_NS -> ""; // default namespace
             case CAC_NS -> "cac";
             case CBC_NS -> "cbc";
             default -> suggestion;

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblCreditNoteParserTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblCreditNoteParserTest.java
@@ -1,0 +1,23 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
+
+class UblCreditNoteParserTest {
+
+    @Test
+    void parsesSampleCreditNote() throws Exception {
+        String xml = Files.readString(Path.of("src/test/resources/sample-creditnote.xml"));
+        UblCreditNoteParser parser = new UblCreditNoteParser();
+        CreditNoteType creditNote = parser.parse(xml);
+        assertNotNull(creditNote);
+        assertEquals("CN758494", creditNote.getID().getValue());
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblCreditNoteWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblCreditNoteWriterTest.java
@@ -1,0 +1,39 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
+
+@Slf4j
+class UblCreditNoteWriterTest {
+
+    @Test
+    void writesCreditNoteToXmlString() throws Exception {
+        String xml = Files.readString(Path.of("src/test/resources/sample-creditnote.xml"));
+        UblCreditNoteParser parser = new UblCreditNoteParser();
+        CreditNoteType creditNote = parser.parse(xml);
+
+        UblCreditNoteWriter writer = new UblCreditNoteWriter();
+        String out = writer.writeToString(creditNote);
+
+        Path outFile = Path.of("target", "generated-creditnote.xml");
+        Files.createDirectories(outFile.getParent());
+        writer.write(creditNote, outFile);
+        log.info("Written credit note to {}", outFile.toAbsolutePath());
+
+        assertNotNull(out);
+        assertFalse(out.isEmpty());
+
+        CreditNoteType parsed = parser.parse(out);
+
+        assertEquals(creditNote.getID().getValue(), parsed.getID().getValue());
+        assertTrue(out.contains("<CreditNote xmlns=\"urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2\""));
+        assertFalse(out.contains("CommonExtensionComponents-2"));
+    }
+}

--- a/peppol-batch/src/test/resources/sample-creditnote.xml
+++ b/peppol-batch/src/test/resources/sample-creditnote.xml
@@ -1,0 +1,159 @@
+<CreditNote xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+<cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+<cbc:CustomizationID>urn:oasis:names:specification:ubl:xpath:CreditNote-2.0:sbs-1.0-draft</cbc:CustomizationID>
+<cbc:ProfileID>bpid:urn:oasis:names:draft:bpss:ubl-2-sbs-credit-notification-draft</cbc:ProfileID>
+<cbc:ID>CN758494</cbc:ID>
+<cbc:CopyIndicator>false</cbc:CopyIndicator>
+<cbc:UUID>349ABBAE-DF9D-40B4-849F-94C5FF9D1AF4</cbc:UUID>
+<cbc:IssueDate>2005-06-25</cbc:IssueDate>
+<cbc:TaxPointDate>2005-06-21</cbc:TaxPointDate>
+<cbc:Note>sample</cbc:Note>
+<cac:AccountingSupplierParty>
+<cbc:CustomerAssignedAccountID>CO001</cbc:CustomerAssignedAccountID>
+<cac:Party>
+<cac:PartyName>
+<cbc:Name>Consortial</cbc:Name>
+</cac:PartyName>
+<cac:PostalAddress>
+<cbc:StreetName>Busy Street</cbc:StreetName>
+<cbc:BuildingName>Thereabouts</cbc:BuildingName>
+<cbc:BuildingNumber>56A</cbc:BuildingNumber>
+<cbc:CityName>Farthing</cbc:CityName>
+<cbc:PostalZone>AA99 1BB</cbc:PostalZone>
+<cbc:CountrySubentity>Heremouthshire</cbc:CountrySubentity>
+<cac:AddressLine>
+<cbc:Line>The Roundabout</cbc:Line>
+</cac:AddressLine>
+<cac:Country>
+<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+</cac:Country>
+</cac:PostalAddress>
+<cac:PartyTaxScheme>
+<cbc:RegistrationName>Farthing Purchasing Consortium</cbc:RegistrationName>
+<cbc:CompanyID>175 269 2355</cbc:CompanyID>
+<cbc:ExemptionReason>N/A</cbc:ExemptionReason>
+<cac:TaxScheme>
+<cbc:ID>VAT</cbc:ID>
+<cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+</cac:TaxScheme>
+</cac:PartyTaxScheme>
+<cac:Contact>
+<cbc:Name>Mrs Bouquet</cbc:Name>
+<cbc:Telephone>0158 1233714</cbc:Telephone>
+<cbc:Telefax>0158 1233856</cbc:Telefax>
+<cbc:ElectronicMail>bouquet@fpconsortial.co.uk</cbc:ElectronicMail>
+</cac:Contact>
+</cac:Party>
+</cac:AccountingSupplierParty>
+<cac:AccountingCustomerParty>
+<cbc:CustomerAssignedAccountID>XFB01</cbc:CustomerAssignedAccountID>
+<cbc:SupplierAssignedAccountID>GT00978567</cbc:SupplierAssignedAccountID>
+<cac:Party>
+<cac:PartyName>
+<cbc:Name>IYT Corporation</cbc:Name>
+</cac:PartyName>
+<cac:PostalAddress>
+<cbc:StreetName>Avon Way</cbc:StreetName>
+<cbc:BuildingName>Thereabouts</cbc:BuildingName>
+<cbc:BuildingNumber>56A</cbc:BuildingNumber>
+<cbc:CityName>Bridgtow</cbc:CityName>
+<cbc:PostalZone>ZZ99 1ZZ</cbc:PostalZone>
+<cbc:CountrySubentity>Avon</cbc:CountrySubentity>
+<cac:AddressLine>
+<cbc:Line>3rd Floor, Room 5</cbc:Line>
+</cac:AddressLine>
+<cac:Country>
+<cbc:IdentificationCode>GB</cbc:IdentificationCode>
+</cac:Country>
+</cac:PostalAddress>
+<cac:PartyTaxScheme>
+<cbc:RegistrationName>Bridgtow District Council</cbc:RegistrationName>
+<cbc:CompanyID>12356478</cbc:CompanyID>
+<cbc:ExemptionReason>Local Authority</cbc:ExemptionReason>
+<cac:TaxScheme>
+<cbc:ID>UK VAT</cbc:ID>
+<cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+</cac:TaxScheme>
+</cac:PartyTaxScheme>
+<cac:Contact>
+<cbc:Name>Mr Fred Churchill</cbc:Name>
+<cbc:Telephone>0127 2653214</cbc:Telephone>
+<cbc:Telefax>0127 2653215</cbc:Telefax>
+<cbc:ElectronicMail>fred@iytcorporation.gov.uk</cbc:ElectronicMail>
+</cac:Contact>
+</cac:Party>
+</cac:AccountingCustomerParty>
+<cac:TaxTotal>
+<cbc:TaxAmount currencyID="GBP">17.50</cbc:TaxAmount>
+<cbc:TaxEvidenceIndicator>true</cbc:TaxEvidenceIndicator>
+<cac:TaxSubtotal>
+<cbc:TaxableAmount currencyID="GBP">100.00</cbc:TaxableAmount>
+<cbc:TaxAmount currencyID="GBP">17.50</cbc:TaxAmount>
+<cac:TaxCategory>
+<cbc:ID>A</cbc:ID>
+<cac:TaxScheme>
+<cbc:ID>UK VAT</cbc:ID>
+<cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:TaxSubtotal>
+</cac:TaxTotal>
+<cac:LegalMonetaryTotal>
+<cbc:LineExtensionAmount currencyID="GBP">100.00</cbc:LineExtensionAmount>
+<cbc:TaxExclusiveAmount currencyID="GBP">90.00</cbc:TaxExclusiveAmount>
+<cbc:PayableAmount currencyID="GBP">107.50</cbc:PayableAmount>
+</cac:LegalMonetaryTotal>
+<cac:CreditNoteLine>
+<cbc:ID>1</cbc:ID>
+<cbc:Note>as agreed on phone, the invoice should have been cancelled earlier, apologies</cbc:Note>
+<cbc:CreditedQuantity unitCode="KGM">100</cbc:CreditedQuantity>
+<cbc:LineExtensionAmount currencyID="GBP">100.00</cbc:LineExtensionAmount>
+<cbc:TaxPointDate>2005-06-21</cbc:TaxPointDate>
+<cac:DiscrepancyResponse>
+<cbc:ReferenceID>A00095678</cbc:ReferenceID>
+<cbc:Description>invoice cancelation</cbc:Description>
+</cac:DiscrepancyResponse>
+<cac:BillingReference>
+<cac:InvoiceDocumentReference>
+<cbc:ID>A00095678</cbc:ID>
+<cbc:UUID>849FBBCE-E081-40B4-906C-94C5FF9D1AC3</cbc:UUID>
+<cbc:IssueDate>2005-06-21</cbc:IssueDate>
+</cac:InvoiceDocumentReference>
+</cac:BillingReference>
+<cac:TaxTotal>
+<cbc:TaxAmount currencyID="GBP">17.50</cbc:TaxAmount>
+<cbc:TaxEvidenceIndicator>true</cbc:TaxEvidenceIndicator>
+<cac:TaxSubtotal>
+<cbc:TaxableAmount currencyID="GBP">100.00</cbc:TaxableAmount>
+<cbc:TaxAmount currencyID="GBP">17.50</cbc:TaxAmount>
+<cac:TaxCategory>
+<cbc:ID>A</cbc:ID>
+<cac:TaxScheme>
+<cbc:ID>UK VAT</cbc:ID>
+<cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:TaxSubtotal>
+</cac:TaxTotal>
+<cac:Item>
+<cbc:Description>Acme beeswax</cbc:Description>
+<cbc:Name>beeswax</cbc:Name>
+<cac:BuyersItemIdentification>
+<cbc:ID>6578489</cbc:ID>
+</cac:BuyersItemIdentification>
+<cac:SellersItemIdentification>
+<cbc:ID>17589683</cbc:ID>
+</cac:SellersItemIdentification>
+<cac:ItemInstance>
+<cac:LotIdentification>
+<cbc:LotNumberID>546378239</cbc:LotNumberID>
+<cbc:ExpiryDate>2010-01-01</cbc:ExpiryDate>
+</cac:LotIdentification>
+</cac:ItemInstance>
+</cac:Item>
+<cac:Price>
+<cbc:PriceAmount currencyID="GBP">1.00</cbc:PriceAmount>
+<cbc:BaseQuantity unitCode="KGM">1</cbc:BaseQuantity>
+</cac:Price>
+</cac:CreditNoteLine>
+</CreditNote>


### PR DESCRIPTION
## Summary
- add `UblCreditNoteParser` and `UblCreditNoteWriter`
- support credit notes in the `UblNamespacePrefixMapper`
- document credit note usage in README
- add tests and sample CreditNote XML

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -Dtest=UblCreditNoteWriterTest -DfailIfNoTests=false test` *(fails: Non-resolvable parent POM)*
- `mvn -q -Dtest=UblCreditNoteParserTest -DfailIfNoTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68657f0e37e48327835924bb847b7cc9