### PR TITLE
Implement ResourceAwareItemReaderItemStream

### DIFF
--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceParserTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceParserTest.java
@@ -2,6 +2,7 @@ package com.example.peppol.batch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,5 +20,18 @@ class UblInvoiceParserTest {
         InvoiceType invoice = parser.parse(xml);
         assertNotNull(invoice);
         assertEquals("TickstarAP-BIS3-test-01", invoice.getID().getValue());
+    }
+
+    @Test
+    void readsInvoiceAsItemReader() throws Exception {
+        UblInvoiceParser reader = new UblInvoiceParser();
+        reader.setResource(new org.springframework.core.io.FileSystemResource("src/test/resources/complex-invoice.xml"));
+        reader.open(new org.springframework.batch.item.ExecutionContext());
+        InvoiceType invoice = reader.read();
+        reader.close();
+        assertNotNull(invoice);
+        assertEquals("TickstarAP-BIS3-test-01", invoice.getID().getValue());
+        // Ensure subsequent reads return null
+        assertNull(reader.read());
     }
 }


### PR DESCRIPTION
## Summary
- implement `ResourceAwareItemReaderItemStream<InvoiceType>` in `UblInvoiceParser`
- add tests for the new reader behaviour

## Testing
- `mvn -f peppol-batch/pom.xml test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6867b37bb31483279d86aa3de52294ec