### PR TITLE
Rename UBL parser classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ java -jar target/peppol-batch-0.0.1-SNAPSHOT.jar
 
 The XML files will be created in the `output` directory with the same file names.
 
-The batch steps internally rely on `UblInvoiceParser` to read each invoice into
+The batch steps internally rely on `XmlInvoiceReader` to read each invoice into
 `InvoiceType` objects and `UblInvoiceWriter` to write them back to XML.
-`UblCreditNoteParser` and `UblCreditNoteWriter` provide the same functionality
+`XmlCreditNoteReader` and `UblCreditNoteWriter` provide the same functionality
 for credit notes.
 
 
@@ -53,7 +53,7 @@ for credit notes.
 
 ## Parsing invoices to Java objects
 
-The project includes a simple `UblInvoiceParser` that uses the `peppol-ubl21`
+The project includes a simple `XmlInvoiceReader` that uses the `peppol-ubl21`
 library to convert invoice XML into JAXB classes. The following snippet parses
 
 
@@ -61,7 +61,7 @@ an invoice and prints its ID:
 
 ```java
 String xml = Files.readString(Path.of("complex-invoice.xml"));
-UblInvoiceParser parser = new UblInvoiceParser();
+XmlInvoiceReader parser = new XmlInvoiceReader();
 InvoiceType invoice = parser.parse(xml);
 System.out.println(invoice.getID().getValue());
 ```
@@ -82,7 +82,7 @@ declares the canonical `cac` and `cbc` prefixes.
 Similarly, credit notes can be handled with:
 
 ```java
-UblCreditNoteParser cnParser = new UblCreditNoteParser();
+XmlCreditNoteReader cnParser = new XmlCreditNoteReader();
 CreditNoteType creditNote = cnParser.parse(xml);
 UblCreditNoteWriter cnWriter = new UblCreditNoteWriter();
 cnWriter.write(creditNote, Path.of("credit-note.xml"));

--- a/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceReader.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceReader.java
@@ -22,7 +22,7 @@ import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
  * exposes a simple {@link #parse(String)} method for converting XML into
  * {@link InvoiceType} objects.</p>
  */
-public class UblInvoiceParser implements ResourceAwareItemReaderItemStream<InvoiceType> {
+public class XmlInvoiceReader implements ResourceAwareItemReaderItemStream<InvoiceType> {
 
     private Resource resource;
     private boolean read;

--- a/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/InvoiceReadTasklet.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/InvoiceReadTasklet.java
@@ -2,8 +2,8 @@ package com.example.peppol.batch.tasklet;
 
 import com.example.peppol.batch.CreditNoteRecord;
 import com.example.peppol.batch.InvoiceRecord;
-import com.example.peppol.batch.UblCreditNoteParser;
-import com.example.peppol.batch.UblInvoiceParser;
+import com.example.peppol.batch.XmlCreditNoteReader;
+import com.example.peppol.batch.XmlInvoiceReader;
 import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
 import java.io.InputStream;
@@ -33,8 +33,8 @@ public class InvoiceReadTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        UblInvoiceParser invoiceParser = new UblInvoiceParser();
-        UblCreditNoteParser creditNoteParser = new UblCreditNoteParser();
+        XmlInvoiceReader invoiceParser = new XmlInvoiceReader();
+        XmlCreditNoteReader creditNoteParser = new XmlCreditNoteReader();
 
         List<InvoiceRecord> invoices = new ArrayList<>();
         List<CreditNoteRecord> creditNotes = new ArrayList<>();

--- a/peppol-batch/src/test/java/com/example/peppol/batch/SpecificationsInvoiceTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/SpecificationsInvoiceTest.java
@@ -27,7 +27,7 @@ class SpecificationsInvoiceTest {
         assumeTrue(example.isPresent(), "No XML invoice found in repo");
 
         String xml = Files.readString(example.get());
-        UblInvoiceParser parser = new UblInvoiceParser();
+        XmlInvoiceReader parser = new XmlInvoiceReader();
         assertNotNull(parser.parse(xml));
     }
 
@@ -40,7 +40,7 @@ class SpecificationsInvoiceTest {
         assumeTrue(example.isPresent(), "No XML invoice found in repo");
 
         String xml = Files.readString(example.get());
-        UblInvoiceParser parser = new UblInvoiceParser();
+        XmlInvoiceReader parser = new XmlInvoiceReader();
         assertNotNull(parser.parse(xml));
 
         InvoiceDocument doc = new InvoiceDocument(xml, example.get());

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblCreditNoteWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblCreditNoteWriterTest.java
@@ -16,7 +16,7 @@ class UblCreditNoteWriterTest {
     @Test
     void writesCreditNoteToXmlString() throws Exception {
         String xml = Files.readString(Path.of("src/test/resources/sample-creditnote.xml"));
-        UblCreditNoteParser parser = new UblCreditNoteParser();
+        XmlCreditNoteReader parser = new XmlCreditNoteReader();
         CreditNoteType creditNote = parser.parse(xml);
 
         UblCreditNoteWriter writer = new UblCreditNoteWriter();

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblInvoiceWriterTest.java
@@ -20,7 +20,7 @@ class UblInvoiceWriterTest {
     @Test
     void writesInvoiceToXmlString() throws Exception {
         String xml = Files.readString(Path.of("src/test/resources/complex-invoice.xml"));
-        UblInvoiceParser parser = new UblInvoiceParser();
+        XmlInvoiceReader parser = new XmlInvoiceReader();
         InvoiceType invoice = parser.parse(xml);
 
         UblInvoiceWriter writer = new UblInvoiceWriter();
@@ -45,7 +45,7 @@ class UblInvoiceWriterTest {
     @Test
     void writesInvoiceUsingItemWriter() throws Exception {
         String xml = Files.readString(Path.of("src/test/resources/complex-invoice.xml"));
-        UblInvoiceParser parser = new UblInvoiceParser();
+        XmlInvoiceReader parser = new XmlInvoiceReader();
         InvoiceType invoice = parser.parse(xml);
 
         Path outputDir = Files.createTempDirectory("invoice-item-writer");

--- a/peppol-batch/src/test/java/com/example/peppol/batch/XmlCreditNoteReaderTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/XmlCreditNoteReaderTest.java
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 
 import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
 
-class UblCreditNoteParserTest {
+class XmlCreditNoteReaderTest {
 
     @Test
     void parsesSampleCreditNote() throws Exception {
         String xml = Files.readString(Path.of("src/test/resources/sample-creditnote.xml"));
-        UblCreditNoteParser parser = new UblCreditNoteParser();
+        XmlCreditNoteReader parser = new XmlCreditNoteReader();
         CreditNoteType creditNote = parser.parse(xml);
         assertNotNull(creditNote);
         assertEquals("CN758494", creditNote.getID().getValue());
@@ -24,7 +24,7 @@ class UblCreditNoteParserTest {
     @Test
     void parsesFromInputStream() throws Exception {
         try (var in = Files.newInputStream(Path.of("src/test/resources/sample-creditnote.xml"))) {
-            UblCreditNoteParser parser = new UblCreditNoteParser();
+            XmlCreditNoteReader parser = new XmlCreditNoteReader();
             CreditNoteType creditNote = parser.parse(in);
             assertNotNull(creditNote);
             assertEquals("CN758494", creditNote.getID().getValue());

--- a/peppol-batch/src/test/java/com/example/peppol/batch/XmlInvoiceReaderTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/XmlInvoiceReaderTest.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.Test;
 
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
 
-class UblInvoiceParserTest {
+class XmlInvoiceReaderTest {
 
     @Test
     void parsesComplexInvoice() throws Exception {
         String xml = Files.readString(Path.of("src/test/resources/complex-invoice.xml"));
-        UblInvoiceParser parser = new UblInvoiceParser();
+        XmlInvoiceReader parser = new XmlInvoiceReader();
         InvoiceType invoice = parser.parse(xml);
         assertNotNull(invoice);
         assertEquals("TickstarAP-BIS3-test-01", invoice.getID().getValue());
@@ -24,7 +24,7 @@ class UblInvoiceParserTest {
 
     @Test
     void readsInvoiceAsItemReader() throws Exception {
-        UblInvoiceParser reader = new UblInvoiceParser();
+        XmlInvoiceReader reader = new XmlInvoiceReader();
         reader.setResource(new org.springframework.core.io.FileSystemResource("src/test/resources/complex-invoice.xml"));
         reader.open(new org.springframework.batch.item.ExecutionContext());
         InvoiceType invoice = reader.read();


### PR DESCRIPTION
## Summary
- rename `UblInvoiceParser` to `XmlInvoiceReader`
- rename `UblCreditNoteParser` to `XmlCreditNoteReader`
- update tasklets, tests and README
- make the credit note parser implement `ResourceAwareItemReaderItemStream`

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b92f133b48327a5bb07ca263d684e