### PR TITLE
Add batch steps for invoice/credit note processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ java -jar target/peppol-batch-0.0.1-SNAPSHOT.jar
 The XML files will be created in the `output` directory with the same file names.
 
 The batch steps internally rely on `XmlInvoiceReader` to read each invoice into
-`InvoiceType` objects and `UblInvoiceWriter` to write them back to XML.
+`InvoiceType` objects and `XmlInvoiceWriter` to write them back to XML.
 `XmlCreditNoteReader` and `UblCreditNoteWriter` provide the same functionality
 for credit notes.
 
@@ -67,11 +67,11 @@ System.out.println(invoice.getID().getValue());
 ```
 
 Once an `InvoiceType` object is available it can be written back to XML using
-`UblInvoiceWriter`:
+`XmlInvoiceWriter`:
 
 ```java
 
-UblInvoiceWriter writer = new UblInvoiceWriter(); // main writer
+XmlInvoiceWriter writer = new XmlInvoiceWriter(); // main writer
 Path outFile = Path.of("invoice.xml");
 writer.write(invoice, outFile);
 ```

--- a/peppol-batch/src/main/java/com/example/peppol/batch/BatchConfig.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/BatchConfig.java
@@ -1,6 +1,7 @@
 package com.example.peppol.batch;
 
 import java.nio.file.Path;
+import java.io.IOException;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -9,11 +10,25 @@ import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.file.MultiResourceItemReader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 import com.example.peppol.batch.tasklet.InvoiceReadTasklet;
 import com.example.peppol.batch.tasklet.InvoiceWriteTasklet;
+import com.example.peppol.batch.tasklet.FetchDecryptUnzipTasklet;
+import com.example.peppol.batch.tasklet.PackageAndUploadTasklet;
+import com.example.peppol.batch.tasklet.CleanupTasklet;
+import com.example.peppol.batch.InvoiceXmlWriter;
+import com.example.peppol.batch.InvoiceDocument;
+import com.example.peppol.batch.PdfInvoiceXmlReader;
+import com.example.peppol.batch.XmlInvoiceReader;
+import com.example.peppol.batch.XmlCreditNoteReader;
+import com.example.peppol.batch.XmlInvoiceWriter;
+import com.example.peppol.batch.XmlCreditNoteItemWriter;
+import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
 
 @Configuration
 @EnableBatchProcessing
@@ -29,6 +44,29 @@ public class BatchConfig {
                 .build();
     }
 
+    /**
+     * Job showcasing a simple end-to-end flow including fetching archives,
+     * parsing invoices and credit notes and packaging the results.
+     */
+    @Bean
+    public Job processingJob(JobBuilderFactory jobs,
+                             Step fetchStep,
+                             Step xmlInvoiceStep,
+                             Step xmlCreditNoteStep,
+                             Step pdfInvoiceStep,
+                             Step packageAndUploadStep,
+                             Step cleanupStep) {
+        return jobs.get("processingJob")
+                .incrementer(new RunIdIncrementer())
+                .start(fetchStep)
+                .next(xmlInvoiceStep)
+                .next(xmlCreditNoteStep)
+                .next(pdfInvoiceStep)
+                .next(packageAndUploadStep)
+                .next(cleanupStep)
+                .build();
+    }
+
     @Bean
     public Step readStep(StepBuilderFactory steps) {
         Tasklet readTasklet = new InvoiceReadTasklet(Path.of("input"));
@@ -39,6 +77,77 @@ public class BatchConfig {
     public Step writeStep(StepBuilderFactory steps) {
         Tasklet writeTasklet = new InvoiceWriteTasklet(Path.of("output"));
         return steps.get("writeStep").tasklet(writeTasklet).build();
+    }
+
+    // ---------------------------------------------------------------------
+    // Extended job step definitions
+    // ---------------------------------------------------------------------
+
+    @Bean
+    public Step fetchStep(StepBuilderFactory steps) {
+        Tasklet tasklet = new FetchDecryptUnzipTasklet(Path.of("input"), Path.of("tmp/unzipped"));
+        return steps.get("fetchStep").tasklet(tasklet).build();
+    }
+
+    @Bean
+    public MultiResourceItemReader<InvoiceType> xmlInvoiceReader() throws IOException {
+        MultiResourceItemReader<InvoiceType> reader = new MultiResourceItemReader<>();
+        reader.setResources(new PathMatchingResourcePatternResolver()
+                .getResources("file:" + Path.of("tmp/unzipped").toAbsolutePath() + "/*.xml"));
+        reader.setDelegate(new XmlInvoiceReader());
+        return reader;
+    }
+
+    @Bean
+    public Step xmlInvoiceStep(StepBuilderFactory steps, MultiResourceItemReader<InvoiceType> xmlInvoiceReader) {
+        XmlInvoiceWriter writer = new XmlInvoiceWriter(Path.of("tmp/processed/xml"));
+        return steps.get("xmlInvoiceStep")
+                .<InvoiceType, InvoiceType>chunk(5)
+                .reader(xmlInvoiceReader)
+                .writer(writer)
+                .build();
+    }
+
+    @Bean
+    public MultiResourceItemReader<CreditNoteType> xmlCreditNoteReader() throws IOException {
+        MultiResourceItemReader<CreditNoteType> reader = new MultiResourceItemReader<>();
+        reader.setResources(new PathMatchingResourcePatternResolver()
+                .getResources("file:" + Path.of("tmp/unzipped").toAbsolutePath() + "/*.xml"));
+        reader.setDelegate(new XmlCreditNoteReader());
+        return reader;
+    }
+
+    @Bean
+    public Step xmlCreditNoteStep(StepBuilderFactory steps, MultiResourceItemReader<CreditNoteType> xmlCreditNoteReader) {
+        XmlCreditNoteItemWriter writer = new XmlCreditNoteItemWriter(Path.of("tmp/processed/xml"));
+        return steps.get("xmlCreditNoteStep")
+                .<CreditNoteType, CreditNoteType>chunk(5)
+                .reader(xmlCreditNoteReader)
+                .writer(writer)
+                .build();
+    }
+
+    @Bean
+    public Step pdfInvoiceStep(StepBuilderFactory steps) {
+        PdfInvoiceXmlReader reader = new PdfInvoiceXmlReader(Path.of("tmp/unzipped"));
+        InvoiceXmlWriter writer = new InvoiceXmlWriter(Path.of("tmp/processed/pdf"));
+        return steps.get("pdfInvoiceStep")
+                .<InvoiceDocument, InvoiceDocument>chunk(5)
+                .reader(reader)
+                .writer(writer)
+                .build();
+    }
+
+    @Bean
+    public Step packageAndUploadStep(StepBuilderFactory steps) {
+        Tasklet tasklet = new PackageAndUploadTasklet(Path.of("tmp/processed"), Path.of("upload"));
+        return steps.get("packageAndUploadStep").tasklet(tasklet).build();
+    }
+
+    @Bean
+    public Step cleanupStep(StepBuilderFactory steps) {
+        Tasklet tasklet = new CleanupTasklet(Path.of("tmp"), Path.of("upload"));
+        return steps.get("cleanupStep").tasklet(tasklet).build();
     }
 
 }

--- a/peppol-batch/src/main/java/com/example/peppol/batch/XmlCreditNoteItemWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/XmlCreditNoteItemWriter.java
@@ -1,0 +1,47 @@
+package com.example.peppol.batch;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
+
+/**
+ * Simple {@link ItemWriter} adapter for {@link UblCreditNoteWriter}.
+ */
+public class XmlCreditNoteItemWriter implements ItemWriter<CreditNoteType> {
+
+    private final Path outputDir;
+    private final UblCreditNoteWriter delegate = new UblCreditNoteWriter();
+    private final AtomicInteger counter = new AtomicInteger();
+
+    public XmlCreditNoteItemWriter(Path outputDir) {
+        this.outputDir = outputDir;
+        try {
+            Files.createDirectories(outputDir);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create output directory", e);
+        }
+    }
+
+    @Override
+    public void write(Chunk<? extends CreditNoteType> items) throws Exception {
+        for (CreditNoteType cn : items) {
+            String baseName;
+            if (cn.getID() != null && cn.getID().getValue() != null && !cn.getID().getValue().isBlank()) {
+                baseName = cn.getID().getValue();
+            } else {
+                baseName = "creditnote-" + counter.incrementAndGet();
+            }
+            if (!baseName.contains("CN")) {
+                baseName = "CN-" + baseName;
+            }
+            Path out = outputDir.resolve(baseName + ".xml");
+            delegate.write(cn, out);
+        }
+    }
+}

--- a/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceReader.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceReader.java
@@ -18,7 +18,7 @@ import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
 /**
  * Utility to parse UBL 2.1 invoice XML into JAXB objects.
  *
- * <p>This class acts as the reader counterpart to {@link UblInvoiceWriter} and
+ * <p>This class acts as the reader counterpart to {@link XmlInvoiceWriter} and
  * exposes a simple {@link #parse(String)} method for converting XML into
  * {@link InvoiceType} objects.</p>
  */

--- a/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceWriter.java
@@ -17,7 +17,7 @@ import org.springframework.batch.item.ItemWriter;
 /**
  * Utility to write {@link InvoiceType} instances to XML.
  */
-public class UblInvoiceWriter implements ItemWriter<InvoiceType> {
+public class XmlInvoiceWriter implements ItemWriter<InvoiceType> {
 
     private final Path outputDir;
 
@@ -26,7 +26,7 @@ public class UblInvoiceWriter implements ItemWriter<InvoiceType> {
      * method cannot be used in this case but {@link #write(InvoiceType, Path)}
      * still works.
      */
-    public UblInvoiceWriter() {
+    public XmlInvoiceWriter() {
         this.outputDir = null;
     }
 
@@ -35,7 +35,7 @@ public class UblInvoiceWriter implements ItemWriter<InvoiceType> {
      *
      * @param outputDir directory where invoice XML files will be written
      */
-    public UblInvoiceWriter(Path outputDir) {
+    public XmlInvoiceWriter(Path outputDir) {
         this.outputDir = outputDir;
         try {
             Files.createDirectories(outputDir);
@@ -100,12 +100,15 @@ public class UblInvoiceWriter implements ItemWriter<InvoiceType> {
         }
         int counter = 0;
         for (InvoiceType invoice : items) {
-            String baseName = null;
+            String baseName;
             if (invoice.getID() != null && invoice.getID().getValue() != null
                     && !invoice.getID().getValue().isBlank()) {
                 baseName = invoice.getID().getValue();
             } else {
                 baseName = "invoice-" + (++counter);
+            }
+            if (!baseName.contains("INV")) {
+                baseName = "INV-" + baseName;
             }
             Path out = outputDir.resolve(baseName + ".xml");
             write(invoice, out);

--- a/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/CleanupTasklet.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/CleanupTasklet.java
@@ -1,0 +1,47 @@
+package com.example.peppol.batch.tasklet;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * Deletes temporary directories created during the job run.
+ */
+public class CleanupTasklet implements Tasklet {
+
+    private final Path[] dirs;
+
+    public CleanupTasklet(Path... dirs) {
+        this.dirs = dirs;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        for (Path dir : dirs) {
+            deleteRecursively(dir);
+        }
+        return RepeatStatus.FINISHED;
+    }
+
+    private void deleteRecursively(Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        try (Stream<Path> s = Files.walk(dir)) {
+            s.sorted(Comparator.reverseOrder())
+             .forEach(p -> {
+                 try {
+                     Files.deleteIfExists(p);
+                 } catch (IOException e) {
+                     // ignore cleanup failures
+                 }
+             });
+        }
+    }
+}

--- a/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/FetchDecryptUnzipTasklet.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/FetchDecryptUnzipTasklet.java
@@ -1,0 +1,58 @@
+package com.example.peppol.batch.tasklet;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * Simplified tasklet that simulates fetching archives and extracting them.
+ * <p>
+ * In this example the tasklet merely unzips any <code>.zip</code> files found
+ * in the input directory and places the contents under the working directory.
+ * Encryption and remote download handling should be added in a real
+ * implementation.
+ * </p>
+ */
+public class FetchDecryptUnzipTasklet implements Tasklet {
+
+    private final Path inputDir;
+    private final Path workDir;
+
+    public FetchDecryptUnzipTasklet(Path inputDir, Path workDir) {
+        this.inputDir = inputDir;
+        this.workDir = workDir;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        Files.createDirectories(workDir);
+        try (Stream<Path> s = Files.list(inputDir)) {
+            s.filter(p -> p.toString().toLowerCase().endsWith(".zip"))
+             .forEach(this::unzip);
+        }
+        return RepeatStatus.FINISHED;
+    }
+
+    private void unzip(Path zip) {
+        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(zip))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                Path out = workDir.resolve(entry.getName());
+                Files.createDirectories(out.getParent());
+                Files.copy(zis, out, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to unzip " + zip, e);
+        }
+    }
+}

--- a/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/InvoiceWriteTasklet.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/InvoiceWriteTasklet.java
@@ -1,7 +1,7 @@
 package com.example.peppol.batch.tasklet;
 
 import com.example.peppol.batch.InvoiceRecord;
-import com.example.peppol.batch.UblInvoiceWriter;
+import com.example.peppol.batch.XmlInvoiceWriter;
 import java.nio.file.Path;
 import java.util.List;
 import org.springframework.batch.core.StepContribution;
@@ -26,7 +26,7 @@ public class InvoiceWriteTasklet implements Tasklet {
         List<InvoiceRecord> records = (List<InvoiceRecord>) chunkContext.getStepContext()
                 .getStepExecution().getJobExecution().getExecutionContext().get("invoices");
         if (records != null && !records.isEmpty()) {
-            UblInvoiceWriter writer = new UblInvoiceWriter();
+            XmlInvoiceWriter writer = new XmlInvoiceWriter();
             for (InvoiceRecord r : records) {
                 Path input = r.getSourceFile();
                 String fileName = input.getFileName().toString();

--- a/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/PackageAndUploadTasklet.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/PackageAndUploadTasklet.java
@@ -1,0 +1,51 @@
+package com.example.peppol.batch.tasklet;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Comparator;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * Tasklet that zips the processed files and simulates uploading them.
+ *
+ * <p>Only local filesystem operations are performed in this example. The
+ * resulting archive is created under the provided upload directory.</p>
+ */
+public class PackageAndUploadTasklet implements Tasklet {
+
+    private final Path processedDir;
+    private final Path uploadDir;
+
+    public PackageAndUploadTasklet(Path processedDir, Path uploadDir) {
+        this.processedDir = processedDir;
+        this.uploadDir = uploadDir;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        Files.createDirectories(uploadDir);
+        Path zipFile = uploadDir.resolve("package.zip");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipFile))) {
+            Files.walk(processedDir)
+                .filter(Files::isRegularFile)
+                .forEach(p -> addEntry(zos, processedDir.relativize(p), p));
+        }
+        return RepeatStatus.FINISHED;
+    }
+
+    private void addEntry(ZipOutputStream zos, Path relative, Path file) {
+        try {
+            zos.putNextEntry(new ZipEntry(relative.toString().replace('\\', '/')));
+            Files.copy(file, zos);
+            zos.closeEntry();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to add " + file + " to archive", e);
+        }
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/XmlInvoiceWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/XmlInvoiceWriterTest.java
@@ -15,7 +15,7 @@ import org.springframework.batch.item.Chunk;
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
 
 @Slf4j
-class UblInvoiceWriterTest {
+class XmlInvoiceWriterTest {
 
     @Test
     void writesInvoiceToXmlString() throws Exception {
@@ -23,7 +23,7 @@ class UblInvoiceWriterTest {
         XmlInvoiceReader parser = new XmlInvoiceReader();
         InvoiceType invoice = parser.parse(xml);
 
-        UblInvoiceWriter writer = new UblInvoiceWriter();
+        XmlInvoiceWriter writer = new XmlInvoiceWriter();
         String out = writer.writeToString(invoice);
 
         Path outFile = Path.of("target", "generated-invoice.xml");
@@ -49,7 +49,7 @@ class UblInvoiceWriterTest {
         InvoiceType invoice = parser.parse(xml);
 
         Path outputDir = Files.createTempDirectory("invoice-item-writer");
-        UblInvoiceWriter writer = new UblInvoiceWriter(outputDir);
+        XmlInvoiceWriter writer = new XmlInvoiceWriter(outputDir);
         Chunk<InvoiceType> chunk = new Chunk<>();
         chunk.add(invoice);
         writer.write(chunk);


### PR DESCRIPTION
## Summary
- add tasklets for unzipping archives, packaging results and cleanup
- provide an item writer for `CreditNoteType`
- extend `BatchConfig` with a new end-to-end job using multi-resource readers
- rename invoice/credit note writers and prefix output names with `INV` or `CN`

## Testing
- `mvn -q -pl peppol-batch test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9b91ee7c8327a0bfd9a56d888a2b