### PR TITLE
Fix invoice writer naming

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceWriter.java
@@ -107,9 +107,6 @@ public class XmlInvoiceWriter implements ItemWriter<InvoiceType> {
             } else {
                 baseName = "invoice-" + (++counter);
             }
-            if (!baseName.contains("INV")) {
-                baseName = "INV-" + baseName;
-            }
             Path out = outputDir.resolve(baseName + ".xml");
             write(invoice, out);
         }


### PR DESCRIPTION
## Summary
- fix `XmlInvoiceWriter` so that it does not prefix written invoice file names

## Testing
- `mvn test` *(fails: Could not transfer artifact from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_686ba1e7f1948327aafe2c29cbd92844