### PR TITLE
Refactor XML writers

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblCreditNoteWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblCreditNoteWriter.java
@@ -1,13 +1,7 @@
 package com.example.peppol.batch;
 
-import java.io.StringWriter;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBElement;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Marshaller;
 import javax.xml.namespace.QName;
 import network.oxalis.peppol.ubl2.jaxb.CreditNoteType;
 
@@ -23,32 +17,10 @@ public class UblCreditNoteWriter {
      * @return XML representation
      */
     public String writeToString(CreditNoteType creditNote) {
-        try {
-            JAXBContext ctx = JAXBContext.newInstance(CreditNoteType.class);
-            Marshaller marshaller = ctx.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new UblNamespacePrefixMapper());
-
-            var ext = creditNote.getUBLExtensions();
-            if (ext != null && ext.getUBLExtension().isEmpty()) {
-                creditNote.setUBLExtensions(null);
-            }
-
-            StringWriter sw = new StringWriter();
-            JAXBElement<CreditNoteType> root = new JAXBElement<>(
-                    new QName("urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2", "CreditNote"),
-                    CreditNoteType.class, creditNote);
-
-            marshaller.marshal(root, sw);
-
-            String xml = sw.toString();
-            if (ext == null || ext.getUBLExtension().isEmpty()) {
-                xml = xml.replaceAll(" xmlns:[^=]*=\"urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2\"", "");
-            }
-            return xml;
-        } catch (JAXBException e) {
-            throw new RuntimeException("Failed to marshal credit note", e);
-        }
+        return UblDocumentWriter.writeToString(
+                creditNote,
+                CreditNoteType.class,
+                new QName("urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2", "CreditNote"));
     }
 
     /**
@@ -58,10 +30,10 @@ public class UblCreditNoteWriter {
      * @param output  the target file path
      */
     public void write(CreditNoteType creditNote, Path output) {
-        try {
-            Files.writeString(output, writeToString(creditNote));
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to write credit note to " + output, e);
-        }
+        UblDocumentWriter.write(
+                creditNote,
+                CreditNoteType.class,
+                new QName("urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2", "CreditNote"),
+                output);
     }
 }

--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblDocumentWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblDocumentWriter.java
@@ -1,0 +1,72 @@
+package com.example.peppol.batch;
+
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import javax.xml.namespace.QName;
+
+/**
+ * Generic helper for writing UBL documents to XML.
+ */
+public final class UblDocumentWriter {
+
+    private UblDocumentWriter() {
+    }
+
+    /**
+     * Marshal the given document to a formatted XML string.
+     *
+     * @param document the UBL document instance
+     * @param type     JAXB class of the document
+     * @param qName    root QName to use
+     * @return XML representation
+     */
+    public static <T> String writeToString(T document, Class<T> type, QName qName) {
+        try {
+            JAXBContext ctx = JAXBContext.newInstance(type);
+            Marshaller marshaller = ctx.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new UblNamespacePrefixMapper());
+
+            Object extensions = type.getMethod("getUBLExtensions").invoke(document);
+            boolean emptyExtensions = false;
+            if (extensions != null) {
+                @SuppressWarnings("unchecked")
+                List<Object> list = (List<Object>) extensions.getClass().getMethod("getUBLExtension").invoke(extensions);
+                if (list.isEmpty()) {
+                    type.getMethod("setUBLExtensions", extensions.getClass()).invoke(document, new Object[]{null});
+                    emptyExtensions = true;
+                }
+            }
+
+            StringWriter sw = new StringWriter();
+            JAXBElement<T> root = new JAXBElement<>(qName, type, document);
+            marshaller.marshal(root, sw);
+
+            String xml = sw.toString();
+            if (extensions == null || emptyExtensions) {
+                xml = xml.replaceAll(" xmlns:[^=]*=\"urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2\"", "");
+            }
+            return xml;
+        } catch (JAXBException | ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to marshal UBL document", e);
+        }
+    }
+
+    /**
+     * Write the document to the given file path.
+     */
+    public static <T> void write(T document, Class<T> type, QName qName, Path output) {
+        try {
+            Files.writeString(output, writeToString(document, type, qName));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write UBL document to " + output, e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- deduplicate UBL marshalling logic
- use new UblDocumentWriter in XmlInvoiceWriter and UblCreditNoteWriter

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686cde5361808327ba678c04b6c36ba2