### PR TITLE
Add more unit tests

### DIFF
--- a/peppol-batch/src/test/java/com/example/peppol/batch/CleanupTaskletTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/CleanupTaskletTest.java
@@ -1,0 +1,27 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import com.example.peppol.batch.tasklet.CleanupTasklet;
+
+class CleanupTaskletTest {
+
+    @Test
+    void deletesDirectoriesRecursively() throws Exception {
+        Path dir = Files.createTempDirectory("cleanup");
+        Files.createDirectories(dir.resolve("sub").resolve("nested"));
+        Files.writeString(dir.resolve("sub/file.txt"), "data");
+
+        CleanupTasklet tasklet = new CleanupTasklet(dir);
+        assertEquals(org.springframework.batch.repeat.RepeatStatus.FINISHED,
+                tasklet.execute((StepContribution) null, (ChunkContext) null));
+        assertFalse(Files.exists(dir));
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/FetchDecryptUnzipTaskletTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/FetchDecryptUnzipTaskletTest.java
@@ -1,0 +1,33 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.peppol.batch.tasklet.FetchDecryptUnzipTasklet;
+
+class FetchDecryptUnzipTaskletTest {
+    @Test
+    void unzipsFilesFromInputDirectory() throws Exception {
+        Path inputDir = Files.createTempDirectory("input");
+        Path workDir = Files.createTempDirectory("work");
+
+        Path zip = inputDir.resolve("archive.zip");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+            zos.putNextEntry(new ZipEntry("test.txt"));
+            zos.write("hello".getBytes());
+            zos.closeEntry();
+        }
+
+        FetchDecryptUnzipTasklet tasklet = new FetchDecryptUnzipTasklet(inputDir, workDir);
+        tasklet.execute(null, null);
+
+        assertTrue(Files.exists(workDir.resolve("test.txt")));
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/InvoiceDocumentTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/InvoiceDocumentTest.java
@@ -1,0 +1,17 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class InvoiceDocumentTest {
+    @Test
+    void gettersReturnValues() {
+        Path source = Path.of("invoice1.xml");
+        InvoiceDocument doc = new InvoiceDocument("<Invoice/>", source);
+        assertEquals("<Invoice/>", doc.getXml());
+        assertEquals(source, doc.getSourceFile());
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/PackageAndUploadTaskletTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/PackageAndUploadTaskletTest.java
@@ -1,0 +1,34 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipFile;
+
+import org.junit.jupiter.api.Test;
+
+import com.example.peppol.batch.tasklet.PackageAndUploadTasklet;
+
+class PackageAndUploadTaskletTest {
+    @Test
+    void packagesProcessedFiles() throws Exception {
+        Path processed = Files.createTempDirectory("processed");
+        Files.writeString(processed.resolve("a.txt"), "a");
+        Files.createDirectories(processed.resolve("sub"));
+        Files.writeString(processed.resolve("sub/b.txt"), "b");
+
+        Path upload = Files.createTempDirectory("upload");
+
+        PackageAndUploadTasklet tasklet = new PackageAndUploadTasklet(processed, upload);
+        tasklet.execute(null, null);
+
+        Path zip = upload.resolve("package.zip");
+        assertTrue(Files.exists(zip));
+        try (ZipFile zf = new ZipFile(zip.toFile())) {
+            assertNotNull(zf.getEntry("a.txt"));
+            assertNotNull(zf.getEntry("sub/b.txt"));
+        }
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/PdfInvoiceXmlReaderTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/PdfInvoiceXmlReaderTest.java
@@ -1,0 +1,49 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
+import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
+import org.junit.jupiter.api.Test;
+
+class PdfInvoiceXmlReaderTest {
+    @Test
+    void readsEmbeddedXml() throws Exception {
+        Path dir = Files.createTempDirectory("pdf");
+        Path pdf = dir.resolve("invoice.pdf");
+
+        byte[] xmlBytes = "<Invoice>test</Invoice>".getBytes(StandardCharsets.UTF_8);
+
+        try (PDDocument doc = new PDDocument()) {
+            PDPage page = new PDPage();
+            doc.addPage(page);
+
+            PDAnnotationFileAttachment att = new PDAnnotationFileAttachment();
+            PDComplexFileSpecification fs = new PDComplexFileSpecification();
+            fs.setFile("invoice.xml");
+            PDEmbeddedFile ef = new PDEmbeddedFile(doc, new ByteArrayInputStream(xmlBytes));
+            fs.setEmbeddedFile(ef);
+            att.setFile(fs);
+            page.getAnnotations().add(att);
+
+            doc.save(pdf.toFile());
+        }
+
+        PdfInvoiceXmlReader reader = new PdfInvoiceXmlReader(dir);
+        InvoiceDocument doc = reader.read();
+        assertNotNull(doc);
+        assertEquals("<Invoice>test</Invoice>", doc.getXml());
+        assertEquals(pdf, doc.getSourceFile());
+        assertNull(reader.read());
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblDocumentWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblDocumentWriterTest.java
@@ -1,0 +1,35 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.Test;
+
+class UblDocumentWriterTest {
+
+    public static class DummyDoc {
+        private UBLExtensions extensions;
+        public static class UBLExtensions {
+            private java.util.List<Object> ublExtension = new java.util.ArrayList<>();
+            public java.util.List<Object> getUBLExtension() { return ublExtension; }
+        }
+        public UBLExtensions getUBLExtensions() { return extensions; }
+        public void setUBLExtensions(UBLExtensions extensions) { this.extensions = extensions; }
+    }
+
+    @Test
+    void writesXmlWithoutExtensionsNamespace() throws Exception {
+        DummyDoc doc = new DummyDoc();
+        doc.setUBLExtensions(new DummyDoc.UBLExtensions());
+        String xml = UblDocumentWriter.writeToString(doc, DummyDoc.class, new QName("urn:test", "Dummy"));
+        assertFalse(xml.contains("CommonExtensionComponents-2"));
+
+        Path out = Files.createTempFile("dummy", ".xml");
+        UblDocumentWriter.write(doc, DummyDoc.class, new QName("urn:test", "Dummy"), out);
+        assertTrue(Files.exists(out));
+    }
+}

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblNamespacePrefixMapperTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblNamespacePrefixMapperTest.java
@@ -1,0 +1,16 @@
+package com.example.peppol.batch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class UblNamespacePrefixMapperTest {
+    @Test
+    void returnsPreferredPrefixes() {
+        UblNamespacePrefixMapper mapper = new UblNamespacePrefixMapper();
+        assertEquals("", mapper.getPreferredPrefix("urn:oasis:names:specification:ubl:schema:xsd:Invoice-2", "x", false));
+        assertEquals("cac", mapper.getPreferredPrefix("urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2", "x", false));
+        assertEquals("cbc", mapper.getPreferredPrefix("urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2", "x", false));
+        assertEquals("suggest", mapper.getPreferredPrefix("urn:other", "suggest", false));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for invoice utility classes
- test namespace mapping
- test generic UBL document writer
- add tasklet tests
- add PDF invoice reader test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ce8a5fe048327839cd072dc0e35d9