### PR TITLE
Add cleanup directories property

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/BatchConfig.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/BatchConfig.java
@@ -2,7 +2,9 @@ package com.example.peppol.batch;
 
 import java.nio.file.Path;
 import java.io.IOException;
+import java.util.Arrays;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
@@ -125,8 +127,12 @@ public class BatchConfig {
     }
 
     @Bean
-    public Step cleanupStep(StepBuilderFactory steps) {
-        Tasklet tasklet = new CleanupTasklet(Path.of("tmp"), Path.of("upload"));
+    public Step cleanupStep(StepBuilderFactory steps,
+                            @Value("${cleanup.dirs}") String[] cleanupDirs) {
+        Path[] paths = Arrays.stream(cleanupDirs)
+                .map(Path::of)
+                .toArray(Path[]::new);
+        Tasklet tasklet = new CleanupTasklet(paths);
         return steps.get("cleanupStep").tasklet(tasklet).build();
     }
 

--- a/peppol-batch/src/main/resources/application.properties
+++ b/peppol-batch/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.main.web-application-type=none
 logging.level.root=INFO
+cleanup.dirs=tmp,upload


### PR DESCRIPTION
## Summary
- move cleanup directories to application properties
- inject property into BatchConfig when constructing CleanupTasklet

## Testing
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686cfab69ec883278d632a59f620b5d5