### PR TITLE
Fix recursive deletion on Windows

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/CleanupTasklet.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/tasklet/CleanupTasklet.java
@@ -33,15 +33,16 @@ public class CleanupTasklet implements Tasklet {
         if (!Files.exists(dir)) {
             return;
         }
+        List<Path> paths;
         try (Stream<Path> s = Files.walk(dir)) {
-            s.sorted(Comparator.reverseOrder())
-             .forEach(p -> {
-                 try {
-                     Files.deleteIfExists(p);
-                 } catch (IOException e) {
-                     // ignore cleanup failures
-                 }
-             });
+            paths = s.sorted(Comparator.reverseOrder()).toList();
+        }
+        for (Path p : paths) {
+            try {
+                Files.deleteIfExists(p);
+            } catch (IOException e) {
+                // ignore cleanup failures
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix CleanupTasklet so directories are deleted after the walk stream closes

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686d05f6ad948327ba699e2e55061188