### PR TITLE
Update tests for StepContext usage

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceReader.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceReader.java
@@ -6,6 +6,8 @@ import java.nio.charset.StandardCharsets;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.file.ResourceAwareItemReaderItemStream;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.core.io.Resource;
 
 import jakarta.xml.bind.JAXBContext;
@@ -70,6 +72,10 @@ public class XmlInvoiceReader implements ResourceAwareItemReaderItemStream<Invoi
             return null;
         }
         try (InputStream in = resource.getInputStream()) {
+            StepContext ctx = StepSynchronizationManager.getContext();
+            if (ctx != null) {
+                ctx.getStepExecutionContext().put("current.file.path", resource.getFile().getAbsolutePath());
+            }
             read = true;
             return parse(in);
         }

--- a/peppol-batch/src/test/java/com/example/peppol/batch/XmlInvoiceReaderTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/XmlInvoiceReaderTest.java
@@ -7,6 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+
 import org.junit.jupiter.api.Test;
 
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
@@ -26,11 +30,19 @@ class XmlInvoiceReaderTest {
     void readsInvoiceAsItemReader() throws Exception {
         XmlInvoiceReader reader = new XmlInvoiceReader();
         reader.setResource(new org.springframework.core.io.FileSystemResource("src/test/resources/complex-invoice.xml"));
-        reader.open(new org.springframework.batch.item.ExecutionContext());
+
+        StepExecution stepExecution = new StepExecution("test", new JobExecution(1L));
+        StepSynchronizationManager.register(stepExecution);
+
+        reader.open(stepExecution.getExecutionContext());
         InvoiceType invoice = reader.read();
         reader.close();
+        StepSynchronizationManager.close();
+
         assertNotNull(invoice);
         assertEquals("TickstarAP-BIS3-test-01", invoice.getID().getValue());
+        assertEquals(Path.of("src/test/resources/complex-invoice.xml").toAbsolutePath().toString(),
+                stepExecution.getExecutionContext().get("current.file.path"));
         // Ensure subsequent reads return null
         assertNull(reader.read());
     }


### PR DESCRIPTION
## Summary
- inject `StepSynchronizationManager` context in `XmlInvoiceReader` to store `current.file.path`
- update `XmlInvoiceReaderTest` to register a `StepExecution` and verify the context value

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686d405572c083279187c575121be3e0