### PR TITLE
Ensure standalone attribute uses no

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/UblDocumentWriter.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/UblDocumentWriter.java
@@ -33,6 +33,7 @@ public final class UblDocumentWriter {
             Marshaller marshaller = ctx.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new UblNamespacePrefixMapper());
+            marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
 
             Object extensions = type.getMethod("getUBLExtensions").invoke(document);
             boolean emptyExtensions = false;
@@ -46,6 +47,7 @@ public final class UblDocumentWriter {
             }
 
             StringWriter sw = new StringWriter();
+            sw.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
             JAXBElement<T> root = new JAXBElement<>(qName, type, document);
             marshaller.marshal(root, sw);
 

--- a/peppol-batch/src/test/java/com/example/peppol/batch/UblDocumentWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/UblDocumentWriterTest.java
@@ -32,4 +32,11 @@ class UblDocumentWriterTest {
         UblDocumentWriter.write(doc, DummyDoc.class, new QName("urn:test", "Dummy"), out);
         assertTrue(Files.exists(out));
     }
+
+    @Test
+    void addsXmlDeclarationWithStandaloneNo() throws Exception {
+        DummyDoc doc = new DummyDoc();
+        String xml = UblDocumentWriter.writeToString(doc, DummyDoc.class, new QName("urn:test", "Dummy"));
+        assertTrue(xml.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"));
+    }
 }


### PR DESCRIPTION
## Summary
- update `UblDocumentWriter` to write XML declarations with `standalone="no"`
- add regression test for declaration in `UblDocumentWriterTest`

## Testing
- `mvn test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686d43612f1483279d34596c6b211112