### PR TITLE
Add issue date mapping for CSV invoices

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceMapper.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceMapper.java
@@ -2,12 +2,17 @@ package com.example.peppol.batch.csv;
 
 import org.mapstruct.*;
 
-import network.oxalis.peppol.ubl2.jaxb.cbc.CustomizationIDType;
-import network.oxalis.peppol.ubl2.jaxb.cbc.IDType;
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.CustomizationIDType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.DocumentCurrencyCodeType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.DueDateType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.IDType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.InvoiceTypeCodeType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.IssueDateType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.NoteType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.ProfileIDType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.TaxCurrencyCodeType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.TaxPointDateType;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -22,6 +27,11 @@ public interface CsvInvoiceMapper {
     @Mapping(target = "customizationID", expression = "java(toCustomizationID(item.getCustomizationId()))")
     @Mapping(target = "profileID", expression = "java(toProfileID(item.getProfileId()))")
     @Mapping(target = "invoiceTypeCode", expression = "java(toInvoiceTypeCode(item.getInvoiceTypeCode()))")
+    @Mapping(target = "issueDate", expression = "java(toIssueDate(item.getIssueDate()))")
+    @Mapping(target = "dueDate", expression = "java(toDueDate(item.getDueDate()))")
+    @Mapping(target = "taxPointDate", expression = "java(toTaxPointDate(item.getTaxPointDate()))")
+    @Mapping(target = "documentCurrencyCode", expression = "java(toDocumentCurrencyCode(item.getDocumentCurrencyCode()))")
+    @Mapping(target = "taxCurrencyCode", expression = "java(toTaxCurrencyCode(item.getTaxCurrencyCode()))")
     @Mapping(target = "note", expression = "java(item.getNote() == null ? new java.util.ArrayList<>() : new java.util.ArrayList<>(java.util.Collections.singletonList(toNote(item.getNote()))))")
     InvoiceType toInvoice(CsvInvoiceRecord item);
 
@@ -76,6 +86,41 @@ public interface CsvInvoiceMapper {
     default NoteType toNote(String value) {
         if (value == null) return null;
         NoteType t = new NoteType();
+        t.setValue(value);
+        return t;
+    }
+
+    default IssueDateType toIssueDate(String value) {
+        if (value == null) return null;
+        IssueDateType t = new IssueDateType();
+        t.setValue(java.time.LocalDate.parse(value));
+        return t;
+    }
+
+    default DueDateType toDueDate(String value) {
+        if (value == null) return null;
+        DueDateType t = new DueDateType();
+        t.setValue(java.time.LocalDate.parse(value));
+        return t;
+    }
+
+    default TaxPointDateType toTaxPointDate(String value) {
+        if (value == null) return null;
+        TaxPointDateType t = new TaxPointDateType();
+        t.setValue(java.time.LocalDate.parse(value));
+        return t;
+    }
+
+    default DocumentCurrencyCodeType toDocumentCurrencyCode(String value) {
+        if (value == null) return null;
+        DocumentCurrencyCodeType t = new DocumentCurrencyCodeType();
+        t.setValue(value);
+        return t;
+    }
+
+    default TaxCurrencyCodeType toTaxCurrencyCode(String value) {
+        if (value == null) return null;
+        TaxCurrencyCodeType t = new TaxCurrencyCodeType();
         t.setValue(value);
         return t;
     }

--- a/peppol-batch/src/test/java/com/example/peppol/batch/csv/CsvInvoiceProcessorTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/csv/CsvInvoiceProcessorTest.java
@@ -35,6 +35,11 @@ class CsvInvoiceProcessorTest {
         assertEquals("TickstarAP-BIS3-test-01", invoice.getID().getValue());
         assertEquals("urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0",
                 invoice.getCustomizationID().getValue());
+        assertEquals(java.time.LocalDate.parse("2023-12-19"), invoice.getIssueDate().getValue());
+        assertEquals(java.time.LocalDate.parse("2024-01-18"), invoice.getDueDate().getValue());
+        assertEquals(java.time.LocalDate.parse("2023-12-19"), invoice.getTaxPointDate().getValue());
+        assertEquals("EUR", invoice.getDocumentCurrencyCode().getValue());
+        assertEquals("SEK", invoice.getTaxCurrencyCode().getValue());
         assertEquals("CHS123",
                 invoice.getInvoiceLine().get(0).getItem().getAdditionalItemProperty().get(0).getValue().getValue());
     }


### PR DESCRIPTION
## Summary
- map additional CSV fields to `InvoiceType`
- add tests for new fields

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f9ec323e48327b42721543affdd1e