### PR TITLE
Fix date conversion for JAXB generated types

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceMapper.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceMapper.java
@@ -2,6 +2,11 @@ package com.example.peppol.batch.csv;
 
 import org.mapstruct.*;
 
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.CustomizationIDType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.DocumentCurrencyCodeType;
@@ -93,21 +98,21 @@ public interface CsvInvoiceMapper {
     default IssueDateType toIssueDate(String value) {
         if (value == null) return null;
         IssueDateType t = new IssueDateType();
-        t.setValue(java.time.LocalDate.parse(value));
+        t.setValue(toXmlDate(value));
         return t;
     }
 
     default DueDateType toDueDate(String value) {
         if (value == null) return null;
         DueDateType t = new DueDateType();
-        t.setValue(java.time.LocalDate.parse(value));
+        t.setValue(toXmlDate(value));
         return t;
     }
 
     default TaxPointDateType toTaxPointDate(String value) {
         if (value == null) return null;
         TaxPointDateType t = new TaxPointDateType();
-        t.setValue(java.time.LocalDate.parse(value));
+        t.setValue(toXmlDate(value));
         return t;
     }
 
@@ -123,5 +128,19 @@ public interface CsvInvoiceMapper {
         TaxCurrencyCodeType t = new TaxCurrencyCodeType();
         t.setValue(value);
         return t;
+    }
+
+    private XMLGregorianCalendar toXmlDate(String value) {
+        java.time.LocalDate local = java.time.LocalDate.parse(value);
+        try {
+            return DatatypeFactory.newInstance()
+                    .newXMLGregorianCalendarDate(
+                            local.getYear(),
+                            local.getMonthValue(),
+                            local.getDayOfMonth(),
+                            DatatypeConstants.FIELD_UNDEFINED);
+        } catch (DatatypeConfigurationException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/peppol-batch/src/test/java/com/example/peppol/batch/csv/CsvInvoiceProcessorTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/csv/CsvInvoiceProcessorTest.java
@@ -3,6 +3,11 @@ package com.example.peppol.batch.csv;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import org.junit.jupiter.api.Test;
 
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
@@ -35,12 +40,25 @@ class CsvInvoiceProcessorTest {
         assertEquals("TickstarAP-BIS3-test-01", invoice.getID().getValue());
         assertEquals("urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0",
                 invoice.getCustomizationID().getValue());
-        assertEquals(java.time.LocalDate.parse("2023-12-19"), invoice.getIssueDate().getValue());
-        assertEquals(java.time.LocalDate.parse("2024-01-18"), invoice.getDueDate().getValue());
-        assertEquals(java.time.LocalDate.parse("2023-12-19"), invoice.getTaxPointDate().getValue());
+        XMLGregorianCalendar issue = toXmlDate("2023-12-19");
+        XMLGregorianCalendar due = toXmlDate("2024-01-18");
+        XMLGregorianCalendar tax = toXmlDate("2023-12-19");
+        assertEquals(issue, invoice.getIssueDate().getValue());
+        assertEquals(due, invoice.getDueDate().getValue());
+        assertEquals(tax, invoice.getTaxPointDate().getValue());
         assertEquals("EUR", invoice.getDocumentCurrencyCode().getValue());
         assertEquals("SEK", invoice.getTaxCurrencyCode().getValue());
         assertEquals("CHS123",
                 invoice.getInvoiceLine().get(0).getItem().getAdditionalItemProperty().get(0).getValue().getValue());
+    }
+
+    private XMLGregorianCalendar toXmlDate(String value) throws DatatypeConfigurationException {
+        java.time.LocalDate local = java.time.LocalDate.parse(value);
+        return DatatypeFactory.newInstance()
+                .newXMLGregorianCalendarDate(
+                        local.getYear(),
+                        local.getMonthValue(),
+                        local.getDayOfMonth(),
+                        DatatypeConstants.FIELD_UNDEFINED);
     }
 }


### PR DESCRIPTION
## Summary
- convert `LocalDate` values to `XMLGregorianCalendar` in `CsvInvoiceMapper`
- update CsvInvoiceProcessorTest expectations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686fa2e43ea08327940e72ce2163776f