### PR TITLE
Fix step context update in XmlInvoiceReader

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceReader.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/XmlInvoiceReader.java
@@ -74,7 +74,8 @@ public class XmlInvoiceReader implements ResourceAwareItemReaderItemStream<Invoi
         try (InputStream in = resource.getInputStream()) {
             StepContext ctx = StepSynchronizationManager.getContext();
             if (ctx != null) {
-                ctx.getStepExecutionContext().put("current.file.path", resource.getFile().getAbsolutePath());
+                ctx.getStepExecution().getExecutionContext()
+                        .put("current.file.path", resource.getFile().getAbsolutePath());
             }
             read = true;
             return parse(in);


### PR DESCRIPTION
## Summary
- use the `StepExecution`'s `ExecutionContext` instead of the read-only context in `XmlInvoiceReader`

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_686fa6dfc268832794f838d603906a03