### PR TITLE
Add CSV to XML writer test

### DIFF
--- a/peppol-batch/src/test/java/com/example/peppol/batch/XmlInvoiceWriterTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/XmlInvoiceWriterTest.java
@@ -11,6 +11,14 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.Chunk;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.core.io.FileSystemResource;
+
+import com.example.peppol.batch.csv.CsvInvoiceReader;
+import com.example.peppol.batch.csv.CsvInvoiceRecord;
+import com.example.peppol.batch.csv.CsvInvoiceProcessor;
 
 import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
 
@@ -58,6 +66,36 @@ class XmlInvoiceWriterTest {
         assertTrue(Files.exists(written));
 
         String writtenXml = Files.readString(written);
+        InvoiceType parsed = parser.parse(writtenXml);
+        assertEquals(invoice.getID().getValue(), parsed.getID().getValue());
+    }
+
+    @Test
+    void readsFromCsvAndWritesXml() throws Exception {
+        CsvInvoiceReader csvReader = new CsvInvoiceReader();
+        csvReader.setResource(new FileSystemResource(Path.of("src/test/resources/sample-invoice.csv")));
+
+        StepExecution stepExecution = new StepExecution("csv", new JobExecution(1L));
+        StepSynchronizationManager.register(stepExecution);
+        csvReader.open(stepExecution.getExecutionContext());
+        CsvInvoiceRecord record = csvReader.read();
+        csvReader.close();
+        StepSynchronizationManager.close();
+
+        CsvInvoiceProcessor processor = new CsvInvoiceProcessor();
+        InvoiceType invoice = processor.process(record);
+
+        Path outputDir = Files.createTempDirectory("csv-invoice-writer");
+        XmlInvoiceWriter writer = new XmlInvoiceWriter(outputDir);
+        Chunk<InvoiceType> chunk = new Chunk<>();
+        chunk.add(invoice);
+        writer.write(chunk);
+
+        Path written = outputDir.resolve(invoice.getID().getValue() + ".xml");
+        assertTrue(Files.exists(written));
+
+        String writtenXml = Files.readString(written);
+        XmlInvoiceReader parser = new XmlInvoiceReader();
         InvoiceType parsed = parser.parse(writtenXml);
         assertEquals(invoice.getID().getValue(), parsed.getID().getValue());
     }


### PR DESCRIPTION
## Summary
- extend XmlInvoiceWriterTest to read a CsvInvoiceRecord and write XML

## Testing
- `mvn test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686fe2e7e5608327ab0256c3947e8d68