### PR TITLE
Map CSV fields for extra invoice metadata

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceMapper.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceMapper.java
@@ -11,13 +11,19 @@ import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.CustomizationIDType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.DocumentCurrencyCodeType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.DueDateType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.CopyIndicatorType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.IDType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.InvoiceTypeCodeType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.IssueDateType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.IssueTimeType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.NoteType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.ProfileIDType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.ProfileExecutionIDType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.TaxCurrencyCodeType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.TaxPointDateType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.UBLVersionIDType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.UUIDType;
+import network.oxalis.peppol.ubl2.jaxb.UBLExtensionsType;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -37,6 +43,12 @@ public interface CsvInvoiceMapper {
     @Mapping(target = "taxPointDate", expression = "java(toTaxPointDate(item.getTaxPointDate()))")
     @Mapping(target = "documentCurrencyCode", expression = "java(toDocumentCurrencyCode(item.getDocumentCurrencyCode()))")
     @Mapping(target = "taxCurrencyCode", expression = "java(toTaxCurrencyCode(item.getTaxCurrencyCode()))")
+    @Mapping(target = "UBLVersionID", expression = "java(toUBLVersionID(item.getUblVersionId()))")
+    @Mapping(target = "profileExecutionID", expression = "java(toProfileExecutionID(item.getProfileExecutionId()))")
+    @Mapping(target = "copyIndicator", expression = "java(toCopyIndicator(item.getCopyIndicator()))")
+    @Mapping(target = "UUID", expression = "java(toUUID(item.getUuid()))")
+    @Mapping(target = "issueTime", expression = "java(toIssueTime(item.getIssueTime()))")
+    @Mapping(target = "UBLExtensions", expression = "java(emptyExtensions())")
     @Mapping(target = "note", expression = "java(item.getNote() == null ? new java.util.ArrayList<>() : new java.util.ArrayList<>(java.util.Collections.singletonList(toNote(item.getNote()))))")
     InvoiceType toInvoice(CsvInvoiceRecord item);
 
@@ -130,6 +142,45 @@ public interface CsvInvoiceMapper {
         return t;
     }
 
+    default UBLVersionIDType toUBLVersionID(String value) {
+        if (value == null) return null;
+        UBLVersionIDType t = new UBLVersionIDType();
+        t.setValue(value);
+        return t;
+    }
+
+    default ProfileExecutionIDType toProfileExecutionID(String value) {
+        if (value == null) return null;
+        ProfileExecutionIDType t = new ProfileExecutionIDType();
+        t.setValue(value);
+        return t;
+    }
+
+    default CopyIndicatorType toCopyIndicator(String value) {
+        if (value == null) return null;
+        CopyIndicatorType t = new CopyIndicatorType();
+        t.setValue(Boolean.parseBoolean(value));
+        return t;
+    }
+
+    default UUIDType toUUID(String value) {
+        if (value == null) return null;
+        UUIDType t = new UUIDType();
+        t.setValue(value);
+        return t;
+    }
+
+    default IssueTimeType toIssueTime(String value) {
+        if (value == null) return null;
+        IssueTimeType t = new IssueTimeType();
+        t.setValue(toXmlTime(value));
+        return t;
+    }
+
+    default UBLExtensionsType emptyExtensions() {
+        return new UBLExtensionsType();
+    }
+
     private XMLGregorianCalendar toXmlDate(String value) {
         java.time.LocalDate local = java.time.LocalDate.parse(value);
         try {
@@ -138,6 +189,21 @@ public interface CsvInvoiceMapper {
                             local.getYear(),
                             local.getMonthValue(),
                             local.getDayOfMonth(),
+                            DatatypeConstants.FIELD_UNDEFINED);
+        } catch (DatatypeConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XMLGregorianCalendar toXmlTime(String value) {
+        java.time.LocalTime local = java.time.LocalTime.parse(value);
+        try {
+            return DatatypeFactory.newInstance()
+                    .newXMLGregorianCalendarTime(
+                            local.getHour(),
+                            local.getMinute(),
+                            local.getSecond(),
+                            DatatypeConstants.FIELD_UNDEFINED,
                             DatatypeConstants.FIELD_UNDEFINED);
         } catch (DatatypeConfigurationException e) {
             throw new RuntimeException(e);

--- a/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceRecord.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceRecord.java
@@ -72,6 +72,31 @@ public class CsvInvoiceRecord {
         return getField("TaxCurrencyCode");
     }
 
+    /** Convenience accessor for UBLVersionID */
+    public String getUblVersionId() {
+        return getField("UBLVersionID");
+    }
+
+    /** Convenience accessor for ProfileExecutionID */
+    public String getProfileExecutionId() {
+        return getField("ProfileExecutionID");
+    }
+
+    /** Convenience accessor for CopyIndicator */
+    public String getCopyIndicator() {
+        return getField("CopyIndicator");
+    }
+
+    /** Convenience accessor for UUID */
+    public String getUuid() {
+        return getField("UUID");
+    }
+
+    /** Convenience accessor for IssueTime */
+    public String getIssueTime() {
+        return getField("IssueTime");
+    }
+
     /** Accessor for the chassis value example. */
     public String getChassisValue() {
         return getField("AdditionalItemProperty_cbc_chassisValue");

--- a/peppol-batch/src/test/java/com/example/peppol/batch/csv/CsvInvoiceProcessorTest.java
+++ b/peppol-batch/src/test/java/com/example/peppol/batch/csv/CsvInvoiceProcessorTest.java
@@ -2,6 +2,8 @@ package com.example.peppol.batch.csv;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
@@ -50,6 +52,13 @@ class CsvInvoiceProcessorTest {
         assertEquals("SEK", invoice.getTaxCurrencyCode().getValue());
         assertEquals("CHS123",
                 invoice.getInvoiceLine().get(0).getItem().getAdditionalItemProperty().get(0).getValue().getValue());
+        assertNotNull(invoice.getUBLExtensions());
+        assertTrue(invoice.getUBLExtensions().getUBLExtension().isEmpty());
+        assertNull(invoice.getUBLVersionID());
+        assertNull(invoice.getProfileExecutionID());
+        assertNull(invoice.getCopyIndicator());
+        assertNull(invoice.getUUID());
+        assertNull(invoice.getIssueTime());
     }
 
     private XMLGregorianCalendar toXmlDate(String value) throws DatatypeConfigurationException {


### PR DESCRIPTION
## Summary
- add getters for optional invoice headers in `CsvInvoiceRecord`
- map UBLVersionID, ProfileExecutionID, CopyIndicator, UUID and IssueTime in `CsvInvoiceMapper`
- include UBLExtensions as an empty list to satisfy MapStruct
- cover unmapped fields with new assertions in `CsvInvoiceProcessorTest`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6870bd33f95c8327813fa44fbfa2b862