### PR TITLE
Fix MapStruct FilerException

### DIFF
--- a/peppol-batch/pom.xml
+++ b/peppol-batch/pom.xml
@@ -52,12 +52,6 @@
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-            <version>${mapstruct.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
## Summary
- remove `mapstruct-processor` from dependencies to avoid duplicate annotation processors

## Testing
- `mvn -version`

------
https://chatgpt.com/codex/tasks/task_e_6874d87891f883279afd83cdbc74c813