### PR TITLE
Fix MapStruct Invoice mapper

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/mapper/CsvToInvoiceMapper.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/mapper/CsvToInvoiceMapper.java
@@ -10,11 +10,11 @@ import org.mapstruct.Mappings;
  * Mapper converting a flat {@link InvoiceDocument} loaded from CSV into
  * the UBL {@link InvoiceType} representation.
  */
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = true))
 public interface CsvToInvoiceMapper extends InvoiceMappingHelpers {
 
     @Mappings({
-        @Mapping(target = "iD.value", source = "invoiceNumber"),
+        @Mapping(target = "ID.value", source = "invoiceNumber"),
         @Mapping(target = "issueDate.value", source = "issueDate"),
         @Mapping(target = "dueDate.value", source = "dueDate"),
         @Mapping(target = "invoiceTypeCode.value", source = "invoiceTypeCode"),


### PR DESCRIPTION
## Summary
- avoid Lombok builder in `CsvToInvoiceMapper`
- correct invoice ID mapping property name

## Testing
- `mvn test` *(fails: Could not download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6877c5b3ec348327881ce616de19394d