### PR TITLE
Add custom mapping for paymentMeans column

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceRecord.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceRecord.java
@@ -133,6 +133,13 @@ public class CsvInvoiceRecord {
     private String deliveryDeliveryLocationCountryIdentificationCode;
     @CsvBindByName(column = "Delivery_DeliveryParty_Name")
     private String deliveryDeliveryPartyName;
+    /**
+     * Flat representation of the payment means code used by some CSV files.
+     * When present, this value maps to the first PaymentMeans element in the
+     * resulting UBL document.
+     */
+    @CsvBindByName(column = "paymentMeans")
+    private String paymentMeans;
     @CsvBindByName(column = "PaymentMeans_PaymentMeansCode")
     private String paymentMeansPaymentMeansCode;
     @CsvBindByName(column = "PaymentMeans_PaymentID")


### PR DESCRIPTION
## Summary
- support `paymentMeans` column in `CsvInvoiceRecord`
- handle flat paymentMeans in `CsvInvoiceMapper`
- provide helper methods to convert between `String` and `PaymentMeansType` lists

## Testing
- `mvn -q -DskipTests=true compile` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687952ff1ca4832791dee964bd2f3d24