### PR TITLE
Add InvoiceDocument CSV bindings

### DIFF
--- a/peppol-batch/src/main/java/com/example/peppol/batch/InvoiceDocument.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/InvoiceDocument.java
@@ -1,0 +1,115 @@
+package com.example.peppol.batch;
+
+import com.opencsv.bean.CsvBindByName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Simple POJO representing invoice data extracted from various sources.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvoiceDocument {
+    @CsvBindByName(column = "invoiceNumber")
+    private String invoiceNumber;
+    @CsvBindByName(column = "issueDate")
+    private String issueDate;
+    @CsvBindByName(column = "dueDate")
+    private String dueDate;
+    @CsvBindByName(column = "invoiceTypeCode")
+    private String invoiceTypeCode;
+    @CsvBindByName(column = "note")
+    private String note;
+    @CsvBindByName(column = "buyerReference")
+    private String buyerReference;
+    @CsvBindByName(column = "startDate")
+    private String startDate;
+    @CsvBindByName(column = "endDate")
+    private String endDate;
+    @CsvBindByName(column = "contractDocumentReferenceCbcId")
+    private String contractDocumentReferenceCbcId;
+    @CsvBindByName(column = "supplierEndPoint")
+    private String supplierEndPoint;
+    @CsvBindByName(column = "supplierPartyIdentificationCbcId")
+    private String supplierPartyIdentificationCbcId;
+    @CsvBindByName(column = "supplierPartyNameCbcName")
+    private String supplierPartyNameCbcName;
+    @CsvBindByName(column = "supplierStreetName")
+    private String supplierStreetName;
+    @CsvBindByName(column = "supplierAdditionalStreetName")
+    private String supplierAdditionalStreetName;
+    @CsvBindByName(column = "supplierCityName")
+    private String supplierCityName;
+    @CsvBindByName(column = "supplierPostalZone")
+    private String supplierPostalZone;
+    @CsvBindByName(column = "supplierCountrySubentity")
+    private String supplierCountrySubentity;
+    @CsvBindByName(column = "supplierAddressLineCbcLine")
+    private String supplierAddressLineCbcLine;
+    @CsvBindByName(column = "supplierCountryCbcIdentificationCode")
+    private String supplierCountryCbcIdentificationCode;
+    @CsvBindByName(column = "customerEndPoint")
+    private String customerEndPoint;
+    @CsvBindByName(column = "customerPartyIdentificationCbcId")
+    private String customerPartyIdentificationCbcId;
+    @CsvBindByName(column = "customerPartyNameCbcName")
+    private String customerPartyNameCbcName;
+    @CsvBindByName(column = "customerStreetName")
+    private String customerStreetName;
+    @CsvBindByName(column = "customerAdditionalStreetName")
+    private String customerAdditionalStreetName;
+    @CsvBindByName(column = "customerCityName")
+    private String customerCityName;
+    @CsvBindByName(column = "customerPostalZone")
+    private String customerPostalZone;
+    @CsvBindByName(column = "customerCountrySubentity")
+    private String customerCountrySubentity;
+    @CsvBindByName(column = "customerAddressLineCbcLine")
+    private String customerAddressLineCbcLine;
+    @CsvBindByName(column = "customerCountryCbcIdentificationCode")
+    private String customerCountryCbcIdentificationCode;
+    @CsvBindByName(column = "customerRegistrationName")
+    private String customerRegistrationName;
+    @CsvBindByName(column = "paymentMeans")
+    private String paymentMeans;
+    @CsvBindByName(column = "paymentMeansCbcPaymentId")
+    private String paymentMeansCbcPaymentId;
+    @CsvBindByName(column = "legalMonetaryTotalCbcLineExtensionAmount")
+    private String legalMonetaryTotalCbcLineExtensionAmount;
+    @CsvBindByName(column = "legalMonetaryTotalCbcTaxExclusiveAmount")
+    private String legalMonetaryTotalCbcTaxExclusiveAmount;
+    @CsvBindByName(column = "legalMonetaryTotalCbcTaxInclusiveAmount")
+    private String legalMonetaryTotalCbcTaxInclusiveAmount;
+    @CsvBindByName(column = "legalMonetaryTotalCbcPayableAmount")
+    private String legalMonetaryTotalCbcPayableAmount;
+    @CsvBindByName(column = "invoiceLineCbcId")
+    private String invoiceLineCbcId;
+    @CsvBindByName(column = "invoiceLineCbcInvoicedQuantity")
+    private String invoiceLineCbcInvoicedQuantity;
+    @CsvBindByName(column = "invoiceLineCbcLineExtensionAmount")
+    private String invoiceLineCbcLineExtensionAmount;
+    @CsvBindByName(column = "currencyId")
+    private String currencyId;
+    @CsvBindByName(column = "itemCbcName")
+    private String itemCbcName;
+    @CsvBindByName(column = "invoicePeriodCbcStartDate")
+    private String invoicePeriodCbcStartDate;
+    @CsvBindByName(column = "invoicePeriodCbcEndDate")
+    private String invoicePeriodCbcEndDate;
+    @CsvBindByName(column = "descriptionCbcItem")
+    private String descriptionCbcItem;
+    @CsvBindByName(column = "allowanceChargeCbcChargeIndicator")
+    private String allowanceChargeCbcChargeIndicator;
+    @CsvBindByName(column = "allowanceChargeCbcAmount")
+    private String allowanceChargeCbcAmount;
+    @CsvBindByName(column = "allowanceChargeCbcBaseAmount")
+    private String allowanceChargeCbcBaseAmount;
+    @CsvBindByName(column = "baseAmountCbcCurrencyId")
+    private String baseAmountCbcCurrencyId;
+    @CsvBindByName(column = "allowanceChargeReason")
+    private String allowanceChargeReason;
+}

--- a/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceMapper.java
+++ b/peppol-batch/src/main/java/com/example/peppol/batch/csv/CsvInvoiceMapper.java
@@ -36,6 +36,26 @@ import network.oxalis.peppol.ubl2.jaxb.cbc.NameType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.URIType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.DocumentTypeCodeType;
 import network.oxalis.peppol.ubl2.jaxb.cbc.DocumentDescriptionType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.EndpointIDType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.StreetNameType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.AdditionalStreetNameType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.CityNameType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.PostalZoneType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.CountrySubentityType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.LineType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.IdentificationCodeType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.RegistrationNameType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.LineExtensionAmountType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.TaxExclusiveAmountType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.TaxInclusiveAmountType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.PayableAmountType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.InvoicedQuantityType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.DescriptionType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.ChargeIndicatorType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.AllowanceChargeReasonType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.AmountType;
+import network.oxalis.peppol.ubl2.jaxb.cbc.BaseAmountType;
+import com.example.peppol.batch.InvoiceDocument;
 
 import network.oxalis.peppol.ubl2.jaxb.ecdt.UBLExtensionsType;
 
@@ -95,6 +115,76 @@ public interface CsvInvoiceMapper {
     @Mapping(target = "paymentTermsNote", expression = "java(fromPaymentTerms(invoice.getPaymentTerms()))")
     @Mapping(target = "note", expression = "java(fromNote(invoice.getNote()))")
     CsvInvoiceRecord fromInvoice(InvoiceType invoice);
+
+    // -----------------------------------------------------------------
+    // Mapping for simplified InvoiceDocument representation
+    // -----------------------------------------------------------------
+
+    @Mappings({
+        @Mapping(target = "ID.value", source = "invoiceNumber"),
+        @Mapping(target = "issueDate.value", source = "issueDate"),
+        @Mapping(target = "dueDate.value", source = "dueDate"),
+        @Mapping(target = "invoiceTypeCode.value", source = "invoiceTypeCode"),
+        @Mapping(target = "note[0].value", source = "note"),
+        @Mapping(target = "buyerReference.value", source = "buyerReference"),
+        @Mapping(target = "invoicePeriod.startDate.value", source = "startDate"),
+        @Mapping(target = "invoicePeriod.endDate.value", source = "endDate"),
+        @Mapping(target = "contractDocumentReference[0].ID.value", source = "contractDocumentReferenceCbcId"),
+
+        // Supplier party mapping
+        @Mapping(target = "accountingSupplierParty.party.endpointID.value", source = "supplierEndPoint"),
+        @Mapping(target = "accountingSupplierParty.party.partyIdentification[0].ID.value", source = "supplierPartyIdentificationCbcId"),
+        @Mapping(target = "accountingSupplierParty.party.partyName[0].name.value", source = "supplierPartyNameCbcName"),
+        @Mapping(target = "accountingSupplierParty.party.postalAddress.streetName.value", source = "supplierStreetName"),
+        @Mapping(target = "accountingSupplierParty.party.postalAddress.additionalStreetName.value", source = "supplierAdditionalStreetName"),
+        @Mapping(target = "accountingSupplierParty.party.postalAddress.cityName.value", source = "supplierCityName"),
+        @Mapping(target = "accountingSupplierParty.party.postalAddress.postalZone.value", source = "supplierPostalZone"),
+        @Mapping(target = "accountingSupplierParty.party.postalAddress.countrySubentity.value", source = "supplierCountrySubentity"),
+        @Mapping(target = "accountingSupplierParty.party.postalAddress.addressLine[0].line.value", source = "supplierAddressLineCbcLine"),
+        @Mapping(target = "accountingSupplierParty.party.postalAddress.country.identificationCode.value", source = "supplierCountryCbcIdentificationCode"),
+
+        // Customer party mapping
+        @Mapping(target = "accountingCustomerParty.party.endpointID.value", source = "customerEndPoint"),
+        @Mapping(target = "accountingCustomerParty.party.partyIdentification[0].ID.value", source = "customerPartyIdentificationCbcId"),
+        @Mapping(target = "accountingCustomerParty.party.partyName[0].name.value", source = "customerPartyNameCbcName"),
+        @Mapping(target = "accountingCustomerParty.party.postalAddress.streetName.value", source = "customerStreetName"),
+        @Mapping(target = "accountingCustomerParty.party.postalAddress.additionalStreetName.value", source = "customerAdditionalStreetName"),
+        @Mapping(target = "accountingCustomerParty.party.postalAddress.cityName.value", source = "customerCityName"),
+        @Mapping(target = "accountingCustomerParty.party.postalAddress.postalZone.value", source = "customerPostalZone"),
+        @Mapping(target = "accountingCustomerParty.party.postalAddress.countrySubentity.value", source = "customerCountrySubentity"),
+        @Mapping(target = "accountingCustomerParty.party.postalAddress.addressLine[0].line.value", source = "customerAddressLineCbcLine"),
+        @Mapping(target = "accountingCustomerParty.party.postalAddress.country.identificationCode.value", source = "customerCountryCbcIdentificationCode"),
+        @Mapping(target = "accountingCustomerParty.party.partyLegalEntity[0].registrationName.value", source = "customerRegistrationName"),
+
+        // Monetary totals
+        @Mapping(target = "paymentMeans[0].paymentMeansCode.value", source = "paymentMeans"),
+        @Mapping(target = "paymentMeans[0].paymentID[0].value", source = "paymentMeansCbcPaymentId"),
+        @Mapping(target = "legalMonetaryTotal.lineExtensionAmount.value", source = "legalMonetaryTotalCbcLineExtensionAmount"),
+        @Mapping(target = "legalMonetaryTotal.taxExclusiveAmount.value", source = "legalMonetaryTotalCbcTaxExclusiveAmount"),
+        @Mapping(target = "legalMonetaryTotal.taxInclusiveAmount.value", source = "legalMonetaryTotalCbcTaxInclusiveAmount"),
+        @Mapping(target = "legalMonetaryTotal.payableAmount.value", source = "legalMonetaryTotalCbcPayableAmount"),
+
+        // Invoice line
+        @Mapping(target = "invoiceLine[0].ID.value", source = "invoiceLineCbcId"),
+        @Mapping(target = "invoiceLine[0].invoicedQuantity.value", source = "invoiceLineCbcInvoicedQuantity"),
+        @Mapping(target = "invoiceLine[0].lineExtensionAmount.value", source = "invoiceLineCbcLineExtensionAmount"),
+        @Mapping(target = "invoiceLine[0].lineExtensionAmount.currencyID", source = "currencyId"),
+        @Mapping(target = "invoiceLine[0].item.name.value", source = "itemCbcName"),
+        @Mapping(target = "invoiceLine[0].invoicePeriod.startDate.value", source = "invoicePeriodCbcStartDate"),
+        @Mapping(target = "invoiceLine[0].invoicePeriod.endDate.value", source = "invoicePeriodCbcEndDate"),
+        @Mapping(target = "invoiceLine[0].item.description[0].value", source = "descriptionCbcItem"),
+
+        // Allowance/charge
+        @Mapping(target = "allowanceCharge[0].chargeIndicator.value", source = "allowanceChargeCbcChargeIndicator"),
+        @Mapping(target = "allowanceCharge[0].amount.value", source = "allowanceChargeCbcAmount"),
+        @Mapping(target = "allowanceCharge[0].baseAmount.value", source = "allowanceChargeCbcBaseAmount"),
+        @Mapping(target = "allowanceCharge[0].baseAmount.currencyID", source = "baseAmountCbcCurrencyId"),
+        @Mapping(target = "allowanceCharge[0].allowanceChargeReason.value", source = "allowanceChargeReason")
+    })
+    InvoiceType documentToInvoice(InvoiceDocument doc);
+
+    @InheritInverseConfiguration(name = "documentToInvoice")
+    InvoiceDocument invoiceToDocument(InvoiceType invoice);
 
 
     default IDType toID(String value) {
@@ -472,6 +562,274 @@ public interface CsvInvoiceMapper {
         java.util.List<PaymentMeansType> list = new java.util.ArrayList<>();
         list.add(pm);
         return list;
+    }
+
+    // -----------------------------------------------------------------
+    // Additional converters for InvoiceDocument mapping
+    // -----------------------------------------------------------------
+
+    default StartDateType toStartDate(String value) {
+        if (value == null) return null;
+        StartDateType t = new StartDateType();
+        t.setValue(toXmlDate(value));
+        return t;
+    }
+
+    default String fromStartDate(StartDateType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default EndDateType toEndDate(String value) {
+        if (value == null) return null;
+        EndDateType t = new EndDateType();
+        t.setValue(toXmlDate(value));
+        return t;
+    }
+
+    default String fromEndDate(EndDateType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default EndpointIDType toEndpointID(String value) {
+        if (value == null) return null;
+        EndpointIDType t = new EndpointIDType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromEndpointID(EndpointIDType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default NameType toName(String value) {
+        if (value == null) return null;
+        NameType t = new NameType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromName(NameType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default StreetNameType toStreetName(String value) {
+        if (value == null) return null;
+        StreetNameType t = new StreetNameType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromStreetName(StreetNameType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default AdditionalStreetNameType toAdditionalStreetName(String value) {
+        if (value == null) return null;
+        AdditionalStreetNameType t = new AdditionalStreetNameType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromAdditionalStreetName(AdditionalStreetNameType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default CityNameType toCityName(String value) {
+        if (value == null) return null;
+        CityNameType t = new CityNameType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromCityName(CityNameType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default PostalZoneType toPostalZone(String value) {
+        if (value == null) return null;
+        PostalZoneType t = new PostalZoneType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromPostalZone(PostalZoneType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default CountrySubentityType toCountrySubentity(String value) {
+        if (value == null) return null;
+        CountrySubentityType t = new CountrySubentityType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromCountrySubentity(CountrySubentityType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default LineType toLine(String value) {
+        if (value == null) return null;
+        LineType t = new LineType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromLine(LineType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default IdentificationCodeType toIdentificationCode(String value) {
+        if (value == null) return null;
+        IdentificationCodeType t = new IdentificationCodeType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromIdentificationCode(IdentificationCodeType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default RegistrationNameType toRegistrationName(String value) {
+        if (value == null) return null;
+        RegistrationNameType t = new RegistrationNameType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromRegistrationName(RegistrationNameType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default PaymentMeansCodeType toPaymentMeansCode(String value) {
+        if (value == null) return null;
+        PaymentMeansCodeType t = new PaymentMeansCodeType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromPaymentMeansCode(PaymentMeansCodeType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default PaymentIDType toPaymentID(String value) {
+        if (value == null) return null;
+        PaymentIDType t = new PaymentIDType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromPaymentID(PaymentIDType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default LineExtensionAmountType toLineExtensionAmount(String value) {
+        if (value == null) return null;
+        LineExtensionAmountType t = new LineExtensionAmountType();
+        t.setValue(new java.math.BigDecimal(value));
+        return t;
+    }
+
+    default String fromLineExtensionAmount(LineExtensionAmountType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default TaxExclusiveAmountType toTaxExclusiveAmount(String value) {
+        if (value == null) return null;
+        TaxExclusiveAmountType t = new TaxExclusiveAmountType();
+        t.setValue(new java.math.BigDecimal(value));
+        return t;
+    }
+
+    default String fromTaxExclusiveAmount(TaxExclusiveAmountType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default TaxInclusiveAmountType toTaxInclusiveAmount(String value) {
+        if (value == null) return null;
+        TaxInclusiveAmountType t = new TaxInclusiveAmountType();
+        t.setValue(new java.math.BigDecimal(value));
+        return t;
+    }
+
+    default String fromTaxInclusiveAmount(TaxInclusiveAmountType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default PayableAmountType toPayableAmount(String value) {
+        if (value == null) return null;
+        PayableAmountType t = new PayableAmountType();
+        t.setValue(new java.math.BigDecimal(value));
+        return t;
+    }
+
+    default String fromPayableAmount(PayableAmountType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default InvoicedQuantityType toInvoicedQuantity(String value) {
+        if (value == null) return null;
+        InvoicedQuantityType t = new InvoicedQuantityType();
+        t.setValue(new java.math.BigDecimal(value));
+        return t;
+    }
+
+    default String fromInvoicedQuantity(InvoicedQuantityType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default DescriptionType toDescription(String value) {
+        if (value == null) return null;
+        DescriptionType t = new DescriptionType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromDescription(DescriptionType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default ChargeIndicatorType toChargeIndicator(String value) {
+        if (value == null) return null;
+        ChargeIndicatorType t = new ChargeIndicatorType();
+        t.setValue(Boolean.parseBoolean(value));
+        return t;
+    }
+
+    default String fromChargeIndicator(ChargeIndicatorType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default AllowanceChargeReasonType toAllowanceChargeReason(String value) {
+        if (value == null) return null;
+        AllowanceChargeReasonType t = new AllowanceChargeReasonType();
+        t.setValue(value);
+        return t;
+    }
+
+    default String fromAllowanceChargeReason(AllowanceChargeReasonType t) {
+        return t == null ? null : t.getValue();
+    }
+
+    default AmountType toAmount(String value) {
+        if (value == null) return null;
+        AmountType t = new AmountType();
+        t.setValue(new java.math.BigDecimal(value));
+        return t;
+    }
+
+    default String fromAmount(AmountType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
+    }
+
+    default BaseAmountType toBaseAmount(String value) {
+        if (value == null) return null;
+        BaseAmountType t = new BaseAmountType();
+        t.setValue(new java.math.BigDecimal(value));
+        return t;
+    }
+
+    default String fromBaseAmount(BaseAmountType t) {
+        return t == null || t.getValue() == null ? null : t.getValue().toString();
     }
 
 }


### PR DESCRIPTION
## Summary
- annotate `InvoiceDocument` fields with `@CsvBindByName`
- extend `CsvInvoiceMapper` with mapping methods for `InvoiceDocument`
- add conversion helpers for the new mapping

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687a030e1ef08327b470e385f5c16529