### PR TITLE
Add CSV batch processing example

### DIFF
--- a/peppol-batch/input/invoices.csv
+++ b/peppol-batch/input/invoices.csv
@@ -1,0 +1,3 @@
+"invoiceNumber";"issueDate";"dueDate";"supplierName";"customerName";"currencyId";"lineExtensionAmount"
+"INV-1";"2024-01-01";"2024-01-15";"Supplier A";"Customer A";"EUR";"100.00"
+"INV-2";"2024-01-02";"2024-01-16";"Supplier A";"Customer B";"EUR";"200.00"

--- a/peppol-batch/pom.xml
+++ b/peppol-batch/pom.xml
@@ -29,6 +29,18 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-oxm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
@@ -51,6 +63,11 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
     <build>

--- a/peppol-batch/src/main/java/com/example/csvbatch/InvoiceBatchApplication.java
+++ b/peppol-batch/src/main/java/com/example/csvbatch/InvoiceBatchApplication.java
@@ -1,0 +1,11 @@
+package com.example.csvbatch;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class InvoiceBatchApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(InvoiceBatchApplication.class, args);
+    }
+}

--- a/peppol-batch/src/main/java/com/example/csvbatch/config/BatchConfig.java
+++ b/peppol-batch/src/main/java/com/example/csvbatch/config/BatchConfig.java
@@ -1,0 +1,89 @@
+package com.example.csvbatch.config;
+
+import com.example.csvbatch.model.CsvInvoiceDto;
+import com.example.csvbatch.processor.InvoiceItemProcessor;
+import com.example.csvbatch.writer.PerInvoiceXmlWriter;
+import com.example.peppol.batch.util.CsvHeaderReader;
+import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.file.builder.FlatFileItemReaderBuilder;
+import org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+
+@Configuration
+@EnableBatchProcessing
+public class BatchConfig {
+
+    private final CsvHeaderReader csvHeaderReader;
+    private final InvoiceItemProcessor processor;
+    private final PerInvoiceXmlWriter writer;
+
+    @Value("${batch.input.file:input/invoices.csv}")
+    private String inputFile;
+
+    @Value("${batch.chunk.size:5}")
+    private int chunkSize;
+
+    private String[] fieldNames;
+
+    public BatchConfig(CsvHeaderReader csvHeaderReader,
+                       InvoiceItemProcessor processor,
+                       PerInvoiceXmlWriter writer) {
+        this.csvHeaderReader = csvHeaderReader;
+        this.processor = processor;
+        this.writer = writer;
+    }
+
+    @PostConstruct
+    public void init() throws IOException {
+        this.fieldNames = csvHeaderReader.readHeaders(inputFile);
+    }
+
+    @Bean
+    public FlatFileItemReader<CsvInvoiceDto> reader() {
+        return new FlatFileItemReaderBuilder<CsvInvoiceDto>()
+                .name("csvInvoiceReader")
+                .resource(new FileSystemResource(inputFile))
+                .linesToSkip(1)
+                .delimited().delimiter(";")
+                .names(fieldNames)
+                .fieldSetMapper(new BeanWrapperFieldSetMapper<>() {{
+                    setTargetType(CsvInvoiceDto.class);
+                }})
+                .build();
+    }
+
+    @Bean
+    public Step csvStep(JobRepository jobRepository, PlatformTransactionManager txManager,
+                        ItemReader<CsvInvoiceDto> reader) {
+        return new StepBuilder("csvStep", jobRepository)
+                .<CsvInvoiceDto, InvoiceType>chunk(chunkSize, txManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .build();
+    }
+
+    @Bean
+    public Job invoiceJob(JobRepository jobRepository, Step csvStep) {
+        return new JobBuilder("invoiceJob", jobRepository)
+                .start(csvStep)
+                .build();
+    }
+}

--- a/peppol-batch/src/main/java/com/example/csvbatch/mapper/CsvInvoiceMapper.java
+++ b/peppol-batch/src/main/java/com/example/csvbatch/mapper/CsvInvoiceMapper.java
@@ -1,0 +1,36 @@
+package com.example.csvbatch.mapper;
+
+import com.example.csvbatch.model.CsvInvoiceDto;
+import network.oxalis.peppol.ubl2.jaxb.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface CsvInvoiceMapper {
+
+    @Mapping(target = "id.value", source = "invoiceNumber")
+    @Mapping(target = "issueDate.value", expression = "java(parseDate(dto.getIssueDate()))")
+    @Mapping(target = "dueDate.value", expression = "java(parseDate(dto.getDueDate()))")
+    @Mapping(target = "accountingSupplierParty.party.partyName[0].name.value", source = "supplierName")
+    @Mapping(target = "accountingCustomerParty.party.partyName[0].name.value", source = "customerName")
+    @Mapping(target = "legalMonetaryTotal.lineExtensionAmount.value", expression = "java(parseAmount(dto.getLineExtensionAmount()))")
+    @Mapping(target = "legalMonetaryTotal.lineExtensionAmount.currencyID", source = "currencyId")
+    InvoiceType toInvoice(CsvInvoiceDto dto);
+
+    default XMLGregorianCalendarType parseDate(String date) {
+        if (date == null || date.isBlank()) return null;
+        XMLGregorianCalendarType t = new XMLGregorianCalendarType();
+        t.setValue(LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        return t;
+    }
+
+    default BigDecimal parseAmount(String amount) {
+        if (amount == null || amount.isBlank()) return null;
+        return new BigDecimal(amount);
+    }
+}

--- a/peppol-batch/src/main/java/com/example/csvbatch/model/CsvInvoiceDto.java
+++ b/peppol-batch/src/main/java/com/example/csvbatch/model/CsvInvoiceDto.java
@@ -1,0 +1,17 @@
+package com.example.csvbatch.model;
+
+import lombok.Data;
+
+/**
+ * Simple DTO representing invoice data from CSV.
+ */
+@Data
+public class CsvInvoiceDto {
+    private String invoiceNumber;
+    private String issueDate;
+    private String dueDate;
+    private String supplierName;
+    private String customerName;
+    private String currencyId;
+    private String lineExtensionAmount;
+}

--- a/peppol-batch/src/main/java/com/example/csvbatch/processor/InvoiceItemProcessor.java
+++ b/peppol-batch/src/main/java/com/example/csvbatch/processor/InvoiceItemProcessor.java
@@ -1,0 +1,26 @@
+package com.example.csvbatch.processor;
+
+import com.example.csvbatch.mapper.CsvInvoiceMapper;
+import com.example.csvbatch.model.CsvInvoiceDto;
+import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class InvoiceItemProcessor implements ItemProcessor<CsvInvoiceDto, InvoiceType> {
+
+    private final CsvInvoiceMapper mapper;
+
+    public InvoiceItemProcessor(CsvInvoiceMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public InvoiceType process(CsvInvoiceDto item) {
+        if (!StringUtils.hasText(item.getInvoiceNumber())) {
+            throw new IllegalArgumentException("Invoice number missing");
+        }
+        return mapper.toInvoice(item);
+    }
+}

--- a/peppol-batch/src/main/java/com/example/csvbatch/writer/PerInvoiceXmlWriter.java
+++ b/peppol-batch/src/main/java/com/example/csvbatch/writer/PerInvoiceXmlWriter.java
@@ -1,0 +1,32 @@
+package com.example.csvbatch.writer;
+
+import network.oxalis.peppol.ubl2.jaxb.InvoiceType;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.xml.namespace.QName;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component
+public class PerInvoiceXmlWriter implements ItemWriter<InvoiceType> {
+
+    @Value("${batch.output.directory:output}")
+    private String outputDirectory;
+
+    @Override
+    public void write(Chunk<? extends InvoiceType> items) throws Exception {
+        Path outDir = Path.of(outputDirectory);
+        Files.createDirectories(outDir);
+        for (InvoiceType invoice : items) {
+            String id = invoice.getID() != null && invoice.getID().getValue() != null
+                    ? invoice.getID().getValue() : "invoice";
+            Path file = outDir.resolve(id + ".xml");
+            com.example.peppol.batch.UblDocumentWriter.write(invoice, InvoiceType.class,
+                    new QName("urn:oasis:names:specification:ubl:schema:xsd:Invoice-2", "Invoice"), file);
+        }
+    }
+}

--- a/peppol-batch/src/main/resources/application-csvbatch.properties
+++ b/peppol-batch/src/main/resources/application-csvbatch.properties
@@ -1,0 +1,5 @@
+spring.batch.initialize-schema=always
+spring.batch.job.enabled=false
+batch.input.file=input/invoices.csv
+batch.output.directory=output
+batch.chunk.size=2


### PR DESCRIPTION
## Summary
- extend dependencies for web and validation
- add sample CSV batch job with MapStruct mapper and processor
- output each invoice as separate XML
- include sample input CSV

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687cea67d2bc8327b5e08b4f1a723107